### PR TITLE
Use fixed versions for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "main": "cloudinary.js",
   "dependencies": {
-    "coffee-script": "",
-    "underscore": "",
-    "temp": ""
+    "coffee-script": "1.4.x",
+    "underscore": "1.4.x",
+    "temp": "0.4.x"
   },
   "devDependencies": {
     "mocha": "",


### PR DESCRIPTION
Temp v0.5 started requiring node v0.8 while this package only requires v0.6. 

It's best practise to fix versions so that you aren't at the mercy of upstream providers and suddenly realise something is broken.

Keep temp at v0.4 to respect dependency on node v0.6. Fix coffeescript and underscore at latest stable versions.
