### PR TITLE
Use the new coffeescript's 'register' to prevent global state change

### DIFF
--- a/cloudinary.js
+++ b/cloudinary.js
@@ -1,4 +1,4 @@
-require('coffee-script');
+require('coffee-script/register');
 var _ = require('underscore');
 
 exports.config = require("./lib/config");

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "cloudinary.js",
   "dependencies": {
-    "coffee-script": "1.4.x",
+    "coffee-script": "1.7.x",
     "underscore": "1.4.x"
   },
   "devDependencies": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require expect.js
 -R spec
 --ui bdd
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register


### PR DESCRIPTION
Since requiring coffee-script changes require.extensions globally,
cloudinary would overwrite a project's coffee-script compiler with
it's own version which could lead to version incompatibilities.

The new coffeescript has an explicit register function which takes
this into account allowing multiple coffeescript compiler versions.
