### PR TITLE
Support root path for shared CDN

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -133,26 +133,26 @@
 
   exports.build_custom_headers = build_custom_headers = function(headers) {
     var k, v;
-    if (headers == null) {
-      return void 0;
-    } else if (_.isArray(headers)) {
-
-    } else if (_.isObject(headers)) {
-      headers = [
-        (function() {
-          var _results;
-          _results = [];
-          for (k in headers) {
-            v = headers[k];
-            _results.push(k + ": " + v);
-          }
-          return _results;
-        })()
-      ];
-    } else {
-      return headers;
+    switch (false) {
+      case !(headers == null):
+        return void 0;
+      case !_.isArray(headers):
+        return headers.join("\n");
+      case !_.isObject(headers):
+        return [
+          (function() {
+            var _results;
+            _results = [];
+            for (k in headers) {
+              v = headers[k];
+              _results.push(k + ": " + v);
+            }
+            return _results;
+          })()
+        ].join("\n");
+      default:
+        return headers;
     }
-    return headers.join("\n");
   };
 
   exports.present = present = function(value) {
@@ -385,13 +385,8 @@
       version = preloaded[3];
       public_id = preloaded[4];
     }
-    if (!private_cdn) {
-      if (!!url_suffix) {
-        throw 'URL Suffix only supported in private CDN';
-      }
-      if (use_root_path) {
-        throw 'Root path only supported in private CDN';
-      }
+    if (url_suffix && !private_cdn) {
+      throw 'URL Suffix only supported in private CDN';
     }
     original_source = public_id;
     if (public_id == null) {

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -83,15 +83,15 @@ exports.build_eager = build_eager = (transformations) ->
   ).join("|")
     
 exports.build_custom_headers = build_custom_headers = (headers) ->
-  if !headers?
-    return undefined
-  else if _.isArray(headers) 
-    ;
-  else if _.isObject(headers)
-    headers = [k + ": " + v for k, v of headers]    
-  else
-    return headers
-  return headers.join("\n")
+  return switch
+    when !headers?
+      undefined
+    when _.isArray headers
+      headers.join "\n"
+    when _.isObject headers
+      [k + ": " + v for k, v of headers].join "\n"
+    else
+      headers
 
 exports.present = present = (value) ->
   not _.isUndefined(value) and ("" + value).length > 0
@@ -243,9 +243,9 @@ exports.url = (public_id, options = {}) ->
     version = preloaded[3]
     public_id = preloaded[4]
 
-  if !private_cdn
-    throw 'URL Suffix only supported in private CDN' if !!url_suffix
-    throw 'Root path only supported in private CDN' if use_root_path
+  if url_suffix and not private_cdn
+    throw 'URL Suffix only supported in private CDN'
+
 
   original_source = public_id
   return original_source unless public_id?

--- a/test/uploader.coffee
+++ b/test/uploader.coffee
@@ -26,7 +26,7 @@ describe "uploader", ->
 
   it "should successfully upload url", (done) ->
     this.timeout 5000
-    cloudinary.uploader.upload "http://cloudinary.com/images/logo.png", (result) ->
+    cloudinary.uploader.upload "http://cloudinary.com/images/old_logo.png", (result) ->
       return done(new Error result.error.message) if result.error?
       expect(result.width).to.eql(241)
       expect(result.height).to.eql(51)
@@ -52,11 +52,25 @@ describe "uploader", ->
   
   it "should successfully call explicit api", (done) ->
     this.timeout 5000
+    current = this
     cloudinary.v2.uploader.explicit "cloudinary", type: "twitter_name", eager: [crop: "scale", width: "2.0"], (error, result) ->
-      return done(new Error error.message) if error?
-      url = cloudinary.utils.url("cloudinary", type: "twitter_name", crop: "scale", width: "2.0", format: "png", version: result["version"])
-      expect(result.eager[0].url).to.eql(url)
-      done()
+      unless error?
+        url = cloudinary.utils.url "cloudinary",
+          type: "twitter_name",
+          crop: "scale",
+          width: "2.0",
+          format: "png",
+          version: result["version"]
+        expect(result.eager[0].url).to.eql(url)
+        done()
+      else
+        if error.code is 420
+          console.warn error.message
+          console.warn "Try running '#{current.test.title}' again in 10 minutes"
+          current.test.pending = true
+          done()
+        else
+          done(new Error error.message)
 
   it "should support eager in upload", (done) ->
     this.timeout 5000
@@ -119,7 +133,7 @@ describe "uploader", ->
    
   it "should support timeouts", (done) ->
     this.timeout 5000
-    cloudinary.uploader.upload "http://cloudinary.com/images/logo.png", (result) ->
+    cloudinary.uploader.upload "http://cloudinary.com/images/old_logo.png", (result) ->
       expect(result.error.http_code).to.eql(499)
       expect(result.error.message).to.eql("Request Timeout")
       done()

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -115,8 +115,9 @@ describe "util", ->
     test_cloudinary_url("test", {url_suffix:"hello", private_cdn:true, resource_type:'raw'}, "http://test123-res.cloudinary.com/files/test/hello", {})
     done()
 
-  it "should disllow use_root_path in shared distribution" ,(done)->
-    expect(()-> utils.url("test", {use_root_path:true})).to.be.throwError(/Root path only supported in private CDN/)
+  it "should support use_root_path in shared distribution" ,(done)->
+    test_cloudinary_url("test", {use_root_path:true, private_cdn:false}, "http://res.cloudinary.com/test123/test", {})
+    test_cloudinary_url("test", {use_root_path:true, private_cdn:false, angle:0}, "http://res.cloudinary.com/test123/a_0/test", {})
     done()
 
   it "should support use_root_path for private_cdn" ,(done)->


### PR DESCRIPTION
Support root path for shared CDN + minor hotfixes

 * Allow root path with shared CDN
 * Replaced chained `if` with `switch`
 * Skip explicit test if the api returns 420