### PR TITLE
Update cloudinary.js to copy over options instead of mutating

### DIFF
--- a/cloudinary.js
+++ b/cloudinary.js
@@ -12,7 +12,7 @@ exports.url = function(public_id, options) {
 
 exports.image = function (source, options) {
   var responsive, html, current_class, classes;
-  options = options || {};
+  options = _.extend({}, options);
   source = cloudinary.utils.url(source, options);
   if ("html_width" in options) options["width"] = cloudinary.utils.option_consume(options, "html_width");
   if ("html_height" in options) options["height"] = cloudinary.utils.option_consume(options, "html_height");
@@ -55,7 +55,7 @@ exports.image = function (source, options) {
  */
 exports.video = function (public_id, options) {
   var src, video_options, fallback, source_transformation, source_types, source, multi_source, html;
-  options = options || {};
+  options = _.extend({}, options);
   public_id = public_id.replace(/\.(mp4|ogv|webm)$/, '');
   source_types = cloudinary.utils.option_consume(options, 'source_types', []);
   source_transformation = cloudinary.utils.option_consume(options, 'source_transformation', {});

--- a/test/imagespec.coffee
+++ b/test/imagespec.coffee
@@ -13,10 +13,18 @@ describe 'image helper', ->
     expect(cloudinary.image("hello", format: "png", crop: 'scale', width: 100, height: 100)).to.eql("<img src='http://res.cloudinary.com/test/image/upload/c_scale,h_100,w_100/hello.png' height='100' width='100'/>")
 
   it "should add responsive width transformation", ->
-    expect(cloudinary.image("hello", format: "png", responsive_width: true)).to.eql("<img class='cld-responsive' data-src='http://res.cloudinary.com/test/image/upload/c_limit,w_auto/hello.png'/>")    
+    expect(cloudinary.image("hello", format: "png", responsive_width: true)).to.eql("<img class='cld-responsive' data-src='http://res.cloudinary.com/test/image/upload/c_limit,w_auto/hello.png'/>")
 
   it "should support width auto transformation", ->
-    expect(cloudinary.image("hello", format: "png", width: "auto", crop: "limit")).to.eql("<img class='cld-responsive' data-src='http://res.cloudinary.com/test/image/upload/c_limit,w_auto/hello.png'/>")    
+    expect(cloudinary.image("hello", format: "png", width: "auto", crop: "limit")).to.eql("<img class='cld-responsive' data-src='http://res.cloudinary.com/test/image/upload/c_limit,w_auto/hello.png'/>")
 
   it "should support dpr auto transformation", ->
-    expect(cloudinary.image("hello", format: "png", dpr: "auto")).to.eql("<img class='cld-hidpi' data-src='http://res.cloudinary.com/test/image/upload/dpr_auto/hello.png'/>")    
+    expect(cloudinary.image("hello", format: "png", dpr: "auto")).to.eql("<img class='cld-hidpi' data-src='http://res.cloudinary.com/test/image/upload/dpr_auto/hello.png'/>")
+
+  it "should not mutate the options argument", ->
+    options =
+      fetch_format: 'auto'
+      flags: 'progressive'
+    cloudinary.image('hello', options)
+    expect(options.fetch_format).to.eql('auto')
+    expect(options.flags).to.eql('progressive')

--- a/test/videospec.coffee
+++ b/test/videospec.coffee
@@ -36,7 +36,7 @@ describe "video", ->
       start_offset: 3
     }
     expected_url = VIDEO_UPLOAD_PATH + "ac_acc,so_3,vc_h264/movie"
-    expect(cloudinary.video("movie", options)).to.eql( 
+    expect(cloudinary.video("movie", options)).to.eql(
       "<video height='100' poster='#{expected_url}.jpg' src='#{expected_url}.mp4' width='200'></video>")
 
     delete options['source_types']
@@ -111,7 +111,7 @@ describe "video", ->
 
   it "should generate video tag with configurable poster", ->
     expected_url = VIDEO_UPLOAD_PATH + "movie"
-    
+
     expected_poster_url = 'http://image/somewhere.jpg'
     expect(cloudinary.video("movie", poster: expected_poster_url, source_types: "mp4")).to.eql(
       "<video poster='#{expected_poster_url}' src='#{expected_url}.mp4'></video>")
@@ -129,3 +129,11 @@ describe "video", ->
 
     expect(cloudinary.video("movie", poster: false, source_types: "mp4")).to.eql(
       "<video src='#{expected_url}.mp4'></video>")
+
+  it "should not mutate the options arguement", ->
+    options =
+      video_codec: 'auto'
+      autoplay: true
+    cloudinary.video('hello', options)
+    expect(options.video_codec).to.eql('auto')
+    expect(options.autoplay).to.be.true


### PR DESCRIPTION
Instead of using in the passed in `options` argument in `.image`, we use `_.extend` to make a shallow copy of the `options` object passed in. Therefore, there will be no way of mutating the `options` object directly.

This happens in `.video` too but the `options` are deep cloned later on. I still used `.extend` as I do not know if anything before the deep clone mutates `options`.

Added tests as well :)

Issue: #55 

Side note: We are not deep copying so deeper objects could possibly be mutated. Not worrying about this unless objects to get mutated at a deeper level.