### PR TITLE
Allow to pass cloudinary url in config method

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,25 +1,32 @@
 _ = require("lodash")
 cloudinary_config = undefined
+
+parseConnectionUrl = (url) ->
+  uri = require('url').parse(url, true)
+  cloudinary_config =
+    cloud_name: uri.host,
+    api_key: uri.auth and uri.auth.split(":")[0],
+    api_secret: uri.auth and uri.auth.split(":")[1],
+    private_cdn: uri.pathname?,
+    secure_distribution: uri.pathname and uri.pathname.substring(1)
+  if uri.query?
+    for k, v of uri.query
+      cloudinary_config[k] = v
+
 module.exports = (new_config, new_value) ->
   if !cloudinary_config? || new_config == true
     cloudinary_url = process.env.CLOUDINARY_URL
     if cloudinary_url?
-      uri = require('url').parse(cloudinary_url, true)
-      cloudinary_config =
-        cloud_name: uri.host,
-        api_key: uri.auth and uri.auth.split(":")[0],
-        api_secret: uri.auth and uri.auth.split(":")[1],
-        private_cdn: uri.pathname?,
-        secure_distribution: uri.pathname and uri.pathname.substring(1)
-      if uri.query?        
-        for k, v of uri.query
-          cloudinary_config[k] = v
+      parseConnectionUrl(cloudinary_url)
     else
       cloudinary_config = {}
   if not _.isUndefined(new_value)
     cloudinary_config[new_config] = new_value
   else if _.isString(new_config)
-    return cloudinary_config[new_config]
+    if new_config.match(/cloudinary:\/\//)
+      parseConnectionUrl(new_config)
+    else
+      return cloudinary_config[new_config]
   else if _.isObject(new_config)
     _.extend(cloudinary_config, new_config)
   cloudinary_config

--- a/test/configspec.coffee
+++ b/test/configspec.coffee
@@ -1,0 +1,35 @@
+_ = require("lodash")
+expect = require('expect.js')
+cloudinary = require('../cloudinary')
+
+originalCloudinaryUrl = null
+
+describe 'config', ->
+
+  beforeEach ->
+    cloudinary.config(true) # Reset
+    originalCloudinaryUrl = process.env.CLOUDINARY_URL
+
+  afterEach ->
+    if _.isUndefined(originalCloudinaryUrl)
+      delete process.env.CLOUDINARY_URL
+    else
+      process.env.CLOUDINARY_URL = originalCloudinaryUrl
+
+  it "should set config field when key and value passed", ->
+    cloudinary.config("cloud_name", "test")
+    expect(cloudinary.config('cloud_name')).to.eql("test")
+
+  it "should set config field when object passed", ->
+    cloudinary.config(cloud_name: "test")
+    expect(cloudinary.config('cloud_name')).to.eql("test")
+
+  it "should parse CLOUDINARY_URL env variable if no values passed", ->
+    process.env.CLOUDINARY_URL = "cloudinary://abcdefgh:012345678@test";
+    cloudinary.config(true)
+    expect(cloudinary.config('cloud_name')).to.eql("test")
+
+  it "should parse url-like single string with as CLOUDINARY_URL", ->
+    cloudinary.config("cloudinary://abcdefgh:012345678@test")
+    expect(cloudinary.config('cloud_name')).to.eql("test")
+


### PR DESCRIPTION
I think it would be nice to explicitly pass clodinary_url to config method. Im not 100% happy with this commit since signature with single string param is already taken by getter. Added some tests to cover old and new use cases.

What do you think?