### PR TITLE
Adding samples and test to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 .project
 ./src
+./samples
+./test


### PR DESCRIPTION
Can we please not publish the samples and tests to npm?

These add 25MB+ to the `npm install` payload when cloudinary is used as a dependency for absolutely no reason.

They're fine to be included when someone `git clone`s this repo, that makes sense, but otherwise these are being installed on [17,000+ servers per month](https://www.npmjs.com/package/cloudinary).