### PR TITLE
Migrate depreciated _.include to _.includes

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -67,7 +67,7 @@
     }
     handle_response = function(res) {
       var buffer, err_obj, error;
-      if (_.include([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
+      if (_.includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
         buffer = "";
         error = false;
         res.on("data", function(d) {


### PR DESCRIPTION
The lodash _.include method is depreciated and is removed in 4.0.0. This small PR updates the usage to _.includes, which is already being used by uploader.js