### PR TITLE
Support subfolder overlay url

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -54,6 +54,9 @@ textStyle = (layer)->
 # @return [string] layer transformation string
 # @private
 process_layer = (layer)->
+  if _.isString(layer)
+    layer =
+      public_id: layer
   if _.isPlainObject(layer)
     public_id = layer["public_id"]
     format = layer["format"]

--- a/test/spechelper.coffee
+++ b/test/spechelper.coffee
@@ -25,7 +25,7 @@ expect.Assertion::produceUrl = (url)->
   actualOptions = _.cloneDeep(options)
   actual = utils.url(public_id, actualOptions)
   @assert(
-    true || actual.match(url),
+    actual.match(url),
     ()-> "expected '#{public_id}' and #{JSON.stringify(options)} to produce '#{url}' but got '#{actual}'",
     ()-> "expected '#{public_id}' and #{JSON.stringify(options)} not to produce '#{url}' but got '#{actual}'")
   @

--- a/test/utils_spec.coffee
+++ b/test/utils_spec.coffee
@@ -197,6 +197,7 @@ describe "utils", ->
     layers_options= [
     # [name,                    options,                                          result]
       ["string",                "text:hello",                                     "text:hello"],
+      ["string",                "folder/logo",                                    "folder:logo"],
       ["public_id",             { "public_id": "logo" },                          "logo"],
       ["public_id with folder", { "public_id": "folder/logo" },                   "folder:logo"],
       ["private",               { "public_id": "logo", "type": "private" },       "private:logo"],


### PR DESCRIPTION
# WARNING

This PR will make some tests fail. It is not because of new functionality braking older stuff, it is because a helper method was making all tests using it pass. See #89.

Should this PR be accepted, someone must fix the tests which are now failing.

---

This PR adds support for passing `public_id` string containing folders to an overlay transformation.
Example:
`cloudinary.image("mountain.jpg", { overlay: "folder/cloudinary_icon", width: 100 });`

It does that by wrapping strings into objects when passed into the `process_layer()` method in `utils.coffee`.

You could as well wrap the `public_id` before passing it into the transformation:
`cloudinary.url("mountain.jpg", { overlay: { public_id: "folder/cloudinary_icon" }, width: 100 });`

But this is not currently documented. I say either remove support for passing `public_id` strings entirely and fix the docs, or support folders as well.

This PR fixes #88.
