### PR TITLE
Support = and | characters within context values using escaping + test

### DIFF
--- a/src/uploader.coffee
+++ b/src/uploader.coffee
@@ -211,7 +211,7 @@ call_context_api = (context, command, public_ids = [], callback, options = {}) -
       type: options.type
     }
     if context?
-      params.context = utils.encode_key_value(context)
+      params.context = utils.encode_context(context)
     return [params]
 
 call_api = (action, callback, options, get_params) ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -250,6 +250,15 @@ exports.encode_key_value = (arg) ->
   else
     arg
 
+exports.encode_context = (arg) ->
+  if _.isObject(arg)
+    pairs = for k, v of arg
+      v = v.replace /([=|])/g, (match)-> "\\#{match}"
+      "#{k}=#{v}"
+    pairs.join("|")
+  else
+    arg
+
 exports.build_eager = (transformations) ->
   (for transformation in utils.build_array(transformations)
     transformation = _.clone(transformation)
@@ -415,7 +424,7 @@ exports.updateable_resource_params = (options, params = {}) ->
   params.auto_tagging = options.auto_tagging if options.auto_tagging?
   params.background_removal = options.background_removal if options.background_removal?
   params.categorization = options.categorization if options.categorization?
-  params.context = utils.encode_key_value(options.context) if options.context?
+  params.context = utils.encode_context(options.context) if options.context?
   params.custom_coordinates = utils.encode_double_array(options.custom_coordinates) if options.custom_coordinates?
   params.detection = options.detection if options.detection?
   params.face_coordinates = utils.encode_double_array(options.face_coordinates) if options.face_coordinates?

--- a/test/uploader_spec.coffee
+++ b/test/uploader_spec.coffee
@@ -251,6 +251,15 @@ describe "uploader", ->
                 expect(r1.context).to.be undefined
                 done()
 
+    it "should upload with context containing reserved characters", (done)->
+      context = {key1: 'value1', key2: 'valu\e2', key3: 'val=u|e3', key4: 'val\=ue'}
+      cloudinary.v2.uploader.upload IMAGE_FILE, context: context, (error, result) ->
+        cloudinary.v2.api.resource result.public_id, context: true, (error, result) ->
+          expect(result.context.custom).to.eql(context)
+          done()
+        true
+      true
+
   it "should support timeouts", (done) ->
     # testing a 1ms timeout, nobody is that fast.
     cloudinary.v2.uploader.upload "http://cloudinary.com/images/old_logo.png", timeout: 1, tags: UPLOAD_TAGS, (error, result) ->


### PR DESCRIPTION
Support using "=" and "|" characters within context (resource metadata) values by escaping using backslashes