### PR TITLE
fix normalize_expression when variable is names as a keyword, like "$width"

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,15 +202,20 @@
    */
 
   normalize_expression = function(expression) {
-    var operators, pattern, replaceRE;
+    var operators, pattern, replaceRE, variable_pattern;
     if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
       return expression;
     }
     operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-    pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+    variable_pattern = "\\$\\w*";
+    pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + "|" + variable_pattern + ")";
     replaceRE = new RegExp(pattern, "g");
     expression = expression.replace(replaceRE, function(match) {
-      return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];
+      if (match.startsWith("$")) {
+        return match;
+      } else {
+        return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];
+      }
     });
     return expression.replace(/[ _]+/g, '_');
   };

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -143,10 +143,14 @@ normalize_expression = (expression) ->
   return expression if !isString(expression) || expression.length == 0 || expression.match(/^!.+!$/)
 
   operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*"
-  pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + ")"
+  variable_pattern = "\\$\\w*"
+  pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + "|" + variable_pattern + ")"
   replaceRE = new RegExp(pattern, "g")
   expression = expression.replace replaceRE, (match)->
-    CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match]
+    if match.startsWith "$"
+      match
+    else 
+      CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match]
   expression.replace(/[ _]+/g, '_')
 
 process_if = (ifValue)->

--- a/test/utils_spec.coffee
+++ b/test/utils_spec.coffee
@@ -623,6 +623,13 @@ describe "utils", ->
       ] }
       t = cloudinary.utils.generate_transformation_string options
       expect(t).to.eql("$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end")
+    it "variable names should not be changed event if they are keywords", ->
+      options = { transformation: [
+        {$width: 10 },
+        {width: "$width + 10 + width"},
+      ] }
+      t = cloudinary.utils.generate_transformation_string options
+      expect(t).to.eql("$width_10/w_$width_add_10_add_w")
     it "should support text values", ->
       test_cloudinary_url("sample", {
         effect: "$efname:100",


### PR DESCRIPTION
This fixes the use case when a user sets a variable named like an
keyword, like "$width".

Currently, the definition is ok ("$width_10" is untouched), but usage
is not ok ("w_$width" is converted to "w_$w") which breaks the url).