### PR TITLE
Add support for gs:// urls in uploader

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -67,7 +67,7 @@ exports.upload = function upload(file, callback) {
 
   return call_api("upload", callback, options, function () {
     var params = build_upload_params(options);
-    if (file != null && file.match(/^ftp:|^https?:|^s3:|^data:[^;]*;base64,([a-zA-Z0-9\/+\n=]+)$/)) {
+    if (file != null && file.match(/^ftp:|^https?:|^gs:|^s3:|^data:[^;]*;base64,([a-zA-Z0-9\/+\n=]+)$/)) {
       return [params, { file: file }];
     } else {
       return [params, {}, file];

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -453,7 +453,7 @@ exports.build_custom_headers = function build_custom_headers(headers) {
   }
 };
 
-var TRANSFORMATION_PARAMS = ['angle', 'aspect_ratio', 'audio_codec', 'audio_frequency', 'background', 'bit_rate', 'border', 'color', 'color_space', 'crop', 'default_image', 'delay', 'density', 'dpr', 'duration', 'effect', 'end_offset', 'fetch_format', 'flags', 'gravity', 'height', 'if', 'keyframe_interval', 'offset', 'opacity', 'overlay', 'page', 'prefix', 'quality', 'radius', 'raw_transformation', 'responsive_width', 'size', 'start_offset', 'streaming_profile', 'transformation', 'underlay', 'variables', 'video_codec', 'video_sampling', 'width', 'x', 'y', 'zoom' // + any key that starts with '$'
+var TRANSFORMATION_PARAMS = ['angle', 'aspect_ratio', 'audio_codec', 'audio_frequency', 'background', 'bit_rate', 'border', 'color', 'color_space', 'crop', 'default_image', 'delay', 'density', 'dpr', 'duration', 'effect', 'end_offset', 'fetch_format', 'flags', 'fps', 'gravity', 'height', 'if', 'keyframe_interval', 'offset', 'opacity', 'overlay', 'page', 'prefix', 'quality', 'radius', 'raw_transformation', 'responsive_width', 'size', 'start_offset', 'streaming_profile', 'transformation', 'underlay', 'variables', 'video_codec', 'video_sampling', 'width', 'x', 'y', 'zoom' // + any key that starts with '$'
 ];
 
 exports.generate_transformation_string = function generate_transformation_string(options) {
@@ -539,6 +539,10 @@ exports.generate_transformation_string = function generate_transformation_string
   var overlay = process_layer(utils.option_consume(options, "overlay"));
   var underlay = process_layer(utils.option_consume(options, "underlay"));
   var ifValue = process_if(utils.option_consume(options, "if"));
+  var fps = utils.option_consume(options, 'fps');
+  if (isArray(fps)) {
+    fps = fps.join('-');
+  }
   var params = {
     a: normalize_expression(angle),
     ar: normalize_expression(utils.option_consume(options, "aspect_ratio")),
@@ -549,6 +553,7 @@ exports.generate_transformation_string = function generate_transformation_string
     dpr: normalize_expression(dpr),
     e: normalize_expression(effect),
     fl: flags,
+    fps: fps,
     h: normalize_expression(height),
     ki: normalize_expression(utils.option_consume(options, "keyframe_interval")),
     l: overlay,

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -339,6 +339,7 @@ exports.build_upload_params = function build_upload_params(options) {
     phash: utils.as_safe_bool(options.phash),
     proxy: options.proxy,
     public_id: options.public_id,
+    quality_analysis: utils.as_safe_bool(options.quality_analysis),
     responsive_breakpoints: utils.generate_responsive_breakpoints_string(options["responsive_breakpoints"]),
     return_delete_token: utils.as_safe_bool(options.return_delete_token),
     timestamp: exports.timestamp(),

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -39,7 +39,7 @@ exports.unsigned_upload = function unsigned_upload(file, upload_preset, callback
 exports.upload = function upload(file, callback, options = {}) {
   return call_api("upload", callback, options, function () {
     let params = build_upload_params(options);
-    if ((file != null) && file.match(/^ftp:|^https?:|^s3:|^data:[^;]*;base64,([a-zA-Z0-9\/+\n=]+)$/)) {
+    if ((file != null) && file.match(/^ftp:|^https?:|^gs:|^s3:|^data:[^;]*;base64,([a-zA-Z0-9\/+\n=]+)$/)) {
       return [params, {file: file}];
     } else {
       return [params, {}, file];

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -336,6 +336,7 @@ exports.build_upload_params = function build_upload_params(options) {
     phash: utils.as_safe_bool(options.phash),
     proxy: options.proxy,
     public_id: options.public_id,
+    quality_analysis: utils.as_safe_bool(options.quality_analysis),
     responsive_breakpoints: utils.generate_responsive_breakpoints_string(options["responsive_breakpoints"]),
     return_delete_token: utils.as_safe_bool(options.return_delete_token),
     timestamp: exports.timestamp(),

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -455,6 +455,7 @@ const TRANSFORMATION_PARAMS = [
   'end_offset',
   'fetch_format',
   'flags',
+  'fps',
   'gravity',
   'height',
   'if',
@@ -546,6 +547,10 @@ exports.generate_transformation_string = function generate_transformation_string
   let overlay = process_layer(utils.option_consume(options, "overlay"));
   let underlay = process_layer(utils.option_consume(options, "underlay"));
   let ifValue = process_if(utils.option_consume(options, "if"));
+  let fps = utils.option_consume(options, 'fps');
+  if(isArray(fps)){
+    fps = fps.join('-');
+  }
   let params = {
     a: normalize_expression(angle),
     ar: normalize_expression(utils.option_consume(options, "aspect_ratio")),
@@ -556,6 +561,7 @@ exports.generate_transformation_string = function generate_transformation_string
     dpr: normalize_expression(dpr),
     e: normalize_expression(effect),
     fl: flags,
+    fps: fps,
     h: normalize_expression(height),
     ki: normalize_expression(utils.option_consume(options, "keyframe_interval")),
     l: overlay,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jsdom-global": "2.1.1",
     "mocha": "^5.0.0",
     "nyc": "^13.0.1",
-    "sinon": "^6.1.4"
+    "sinon": "^6.1.4",
+    "webpack-cli": "^3.2.1"
   },
   "scripts": {
     "test": "node_v=$(node --version)z\nif [[ \"${node_v%%.*z}\" == 'v4' ]]\nthen\nnpm run test-es5\nelse\necho 10 && npm run test-es6\nfi",

--- a/test/uploader_spec.js
+++ b/test/uploader_spec.js
@@ -517,6 +517,14 @@ describe("uploader", function() {
       expect(error.message).to.contain("is invalid");
     });
   });
+  it("should support requesting analysis", function() {
+    return cloudinary.v2.uploader.upload(IMAGE_FILE, {
+      quality_analysis: true,
+      tags: UPLOAD_TAGS
+    }).then(function (result) {
+      expect(result).to.have.key("quality_analysis");
+    });
+  });
   describe("upload_chunked", function() {
     this.timeout(helper.TIMEOUT_LONG * 10);
     it("should specify chunk size", function(done) {
@@ -801,9 +809,11 @@ describe("uploader", function() {
             }
           ],
           invalidate: true,
+          quality_analysis: true,
           tags: [TEST_TAG]
         });
-        return sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('invalidate', 1)));
+        sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('invalidate', 1)));
+        sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('quality_analysis', 1)));
       });
     });
     it("should support raw_convert", function() {

--- a/test/uploader_spec.js
+++ b/test/uploader_spec.js
@@ -77,6 +77,35 @@ describe("uploader", function() {
       expect(result.signature).to.eql(expected_signature);
     });
   });
+  describe("remote urls ", function() {
+    var writeSpy;
+    writeSpy = void 0;
+    beforeEach(function() {
+      return writeSpy = sinon.spy(ClientRequest.prototype, 'write');
+    });
+    afterEach(function() {
+      return writeSpy.restore();
+    });
+    it("should send s3:// URLs to server", function() {
+      cloudinary.v2.uploader.upload("s3://test/1.jpg", {
+        tags: UPLOAD_TAGS
+      });
+      sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher('file', "s3://test/1.jpg")));
+    });
+    it("should send gs:// URLs to server", function() {
+      cloudinary.v2.uploader.upload("gs://test/1.jpg", {
+        tags: UPLOAD_TAGS
+      });
+      sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher('file', "gs://test/1.jpg")));
+    });
+    it("should send ftp:// URLs to server", function() {
+      cloudinary.v2.uploader.upload("ftp://example.com/1.jpg", {
+        tags: UPLOAD_TAGS
+      });
+      sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher('file', "ftp://example.com/1.jpg")));
+    });
+  });
+
   describe("rename", function() {
     this.timeout(helper.TIMEOUT_LONG);
     it("should successfully rename a file", function() {

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1383,4 +1383,17 @@ describe("utils", function () {
       expect(srcset.split(', ').length).to.eql(3);
     });
   });
+  describe( 'fps', function(){
+    [
+      [{fps: "24-29.97"}, "fps_24-29.97"],
+      [{fps: 24}, "fps_24"],
+      [{fps: 24.5}, "fps_24.5"],
+      [{fps: "24"}, "fps_24"],
+      [{fps: "-24"}, "fps_-24"],
+      [{fps: [24, 29.97]}, "fps_24-29.97"],
+    ].forEach(function([option, expected]){
+      expect(cloudinary.utils.generate_transformation_string(option)).to.eql(expected);
+    })
+
+  })
 });


### PR DESCRIPTION
URL handling in upload() has special cases for non-local URLs but doesn't support gs: URL prefix
Without this, attempts to use gs: URLs are handled locally, and the file can't be loaded.

Tests pass except `should support requesting ocr analysis` which appears unrelated, and was based on running tests against a cloud which hasn't got access to OCR

Verified `gs://` upload works with an example in my own account, fetched from my own storage bucket on Google Cloud (cloud `stephencloudinary`, public ID `c3uirc0l0gq0eylnhiv0`)