### PR TITLE
[easy] Fix broken links in node sample project readme

### DIFF
--- a/samples/readme.md
+++ b/samples/readme.md
@@ -13,8 +13,8 @@ The basic sample uploads local and remote image to Cloudinary and generates URLs
 ## Photo Album sample
 
 Simple application for uploading images and displaying them in a list.  
-This sample uses [jugglingdb orm](https://github.com/1602/jugglingdb)
-see [schema.js](config/schema.js) for adapter configuration.
+This sample uses [jugglingdb orm](https://github.com/1602/jugglingdb). 
+See [schema.js](photo_album/config/schema.js) for adapter configuration.
 
 ### Setting up
 1. Before running the sample, copy the Environment variable configuration parameters from Cloudinary's [Management Console](https://cloudinary.com/console) of your account into `.env` file of the project or export it (i.e. export CLOUDINARY_URL=xxx).
@@ -28,4 +28,4 @@ see [schema.js](config/schema.js) for adapter configuration.
 
 * [Node integration documentation](http://cloudinary.com/documentation/node_integration)
 * [Image transformations documentation](http://cloudinary.com/documentation/node_image_manipulation)
-* [Node Image Upload] (http://cloudinary.com/documentation/node_image_upload)
+* [Node Image Upload](http://cloudinary.com/documentation/node_image_upload)


### PR DESCRIPTION
The markdown on the last link (Node Image Upload) had an extra space so wasn't rendering on the github site
The link to `schema.js` also was broken, as it wasn't adding the full path

No code changes, just the readme