### PR TITLE
Remove coffee script dependencies and transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,5 @@
   "optionalDependencies": {},
   "engines": {
     "node": ">=0.6"
-  },
-  "browserify": {
-    "transform": [
-      "coffeeify"
-    ]
   }
 }

--- a/samples/basic/package.json
+++ b/samples/basic/package.json
@@ -7,9 +7,6 @@
     "cloudinary": "^1.3.0",
     "dotenv": "1.x"
   },
-  "devDependencies": {
-    "coffee-script": "^1.10.0"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/samples/photo_album/package.json
+++ b/samples/photo_album/package.json
@@ -4,7 +4,7 @@
   "description": "Cloudinary Express demo",
   "main": "server.js",
   "scripts": {
-    "debug": "./node_modules/.bin/supervisor -e 'js|ejs|node|coffee' server.js"
+    "debug": "./node_modules/.bin/supervisor -e 'js|ejs|node' server.js"
   },
   "author": "",
   "license": "ISC",
@@ -22,7 +22,6 @@
     "method-override": "^2.1.2"
   },
   "devDependencies": {
-    "coffee-script": "^1.10.0",
     "supervisor": "^0.6.0"
   }
 }


### PR DESCRIPTION
The browserify transform defined in `package.json` was causing my build to fail due to coffeescript not being a listed dependency.

Seeing as the source code have been refactored in JavaScript, there's no need for the transform anymore. This removes any last trailing references to coffescript.