### PR TITLE
Cleanup test classes after coffeescript migration

### DIFF
--- a/test/access_control_spec.js
+++ b/test/access_control_spec.js
@@ -7,7 +7,6 @@ const cloudinary = require("../cloudinary");
 const build_upload_params = cloudinary.utils.build_upload_params;
 const helper = require('./spechelper');
 const isString = require('lodash/isString');
-var options = null;
 
 const ACL = {
   access_type: 'anonymous',
@@ -27,23 +26,6 @@ describe("Access Control", function() {
     if (!(config.api_key && config.api_secret)) {
       expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
     }
-
-  });
-  this.timeout(helper.TIMEOUT_LONG);
-  after(function() {
-    let config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-    if (!cloudinary.config().keep_test_products) {
-      return cloudinary.v2.api.delete_resources_by_tag(helper.TEST_TAG);
-    }
-  });
-  beforeEach(function() {
-    return options = {
-      public_id: helper.TEST_TAG,
-      tags: [...helper.UPLOAD_TAGS, 'access_control_test']
-    };
   });
   describe("build_upload_params", function() {
     it("should accept a Hash value", function() {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -183,7 +183,7 @@ describe("api", function() {
     it("should allow listing resource_types", function() {
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.resource_types().then(function(result) {
-        return expect(result.resource_types).to.contain("image");
+        expect(result.resource_types).to.contain("image");
       });
     });
     it("should allow listing resources", function() {
@@ -198,7 +198,7 @@ describe("api", function() {
       }).then(function(result) {
         let resource = findByAttr(result.resources, "public_id", publicId);
         expect(resource).not.to.eql(void 0);
-        return expect(resource.type).to.eql("upload");
+        expect(resource.type).to.eql("upload");
       });
     });
     it("should allow listing resources by type", function () {
@@ -249,7 +249,7 @@ describe("api", function() {
     it("should allow listing resources by context key and value", function() {
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.resources_by_context(contextKey, "test").then(function(result) {
-        return expect(result.resources).to.have.length(1);
+        expect(result.resources).to.have.length(1);
       });
     });
     it("should allow listing resources by public ids", function() {
@@ -378,7 +378,7 @@ describe("api", function() {
           .to.not.be.empty();
         return cloudinary.v2.api.resource(PUBLIC_ID_3);
       }).then(function(result) {
-        return expect(result.derived.length).to.eql(0);
+        expect(result.derived.length).to.eql(0);
       });
     });
     it("should allow deleting resources", function() {
@@ -394,10 +394,10 @@ describe("api", function() {
       }).then(function(result) {
         return cloudinary.v2.api.resource(PUBLIC_ID_3);
       }).then(()=>{
-        return expect().fail();
+        expect().fail();
       }).catch(function({error}) {
         expect(error).to.be.an(Object);
-        return expect(error.http_code).to.eql(404);
+        expect(error.http_code).to.eql(404);
       });
     });
     describe("delete_resources_by_prefix", function() {
@@ -415,14 +415,14 @@ describe("api", function() {
         ).then(()=>expect().fail()
         ).catch(function({error}) {
           expect(error).to.be.an(Object);
-          return expect(error.http_code).to.eql(404);
+          expect(error.http_code).to.eql(404);
         });
       });
     });
     describe("delete_resources_by_tag", function() {
       let deleteTestTag = TEST_TAG + "_delete";
       itBehavesLike("accepts next_cursor", cloudinary.v2.api.delete_resources_by_prefix, deleteTestTag);
-      return it("should allow deleting resources by tags", function() {
+      it("should allow deleting resources by tags", function() {
         this.timeout(helper.TIMEOUT_MEDIUM);
         return cloudinary.v2.uploader.upload(IMAGE_FILE, {
           public_id: PUBLIC_ID_4,
@@ -435,7 +435,7 @@ describe("api", function() {
         ).then(()=>expect().fail()
         ).catch(({error}) => {
           expect(error).to.be.an(Object);
-          return expect(error.http_code).to.eql(404);
+          expect(error.http_code).to.eql(404);
         });
       });
     });
@@ -456,7 +456,7 @@ describe("api", function() {
       }).then((result) => expect(result.tags).to.contain(TEST_TAG)
       );
     });
-    return it("should allow listing tag by prefix if not found", function() {
+    it("should allow listing tag by prefix if not found", function() {
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.tags({
         prefix: "api_test_no_such_tag"
@@ -476,21 +476,21 @@ describe("api", function() {
       return cloudinary.v2.api.transformations().then(function(result) {
         expect(result).to.have.key("transformations");
         expect(result.transformations).not.to.be.empty();
-        return expect(result.transformations[0]).to.have.key('used');
+        expect(result.transformations[0]).to.have.key('used');
       });
     });
     it("should allow getting transformation metadata", function() {
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.transformation(EXPLICIT_TRANSFORMATION_NAME).then(function(transformation) {
         expect(transformation).not.to.eql(void 0);
-        return expect(transformation.info).to.eql([EXPLICIT_TRANSFORMATION]);
+        expect(transformation.info).to.eql([EXPLICIT_TRANSFORMATION]);
       });
     });
     it("should allow getting transformation metadata by info", function() {
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.transformation(EXPLICIT_TRANSFORMATION).then(function(transformation) {
         expect(transformation).not.to.eql(void 0);
-        return expect(transformation.info).to.eql([EXPLICIT_TRANSFORMATION]);
+        expect(transformation.info).to.eql([EXPLICIT_TRANSFORMATION]);
       });
     });
     it("should allow updating transformation allowed_for_strict", function() {
@@ -635,7 +635,7 @@ describe("api", function() {
       ).then(() => expect().fail()
       ).catch(({error}) => expect(error.message).to.contain("Can't find"));
     });
-    return it("should allow updating upload_presets", function() {
+    it("should allow updating upload_presets", function() {
       var name ='';
       this.timeout(helper.TIMEOUT_MEDIUM);
       return cloudinary.v2.api.create_upload_preset({
@@ -677,7 +677,7 @@ describe("api", function() {
           sinon.assert.calledWith(request, sinon.match(arg => new RegExp("/resources/image/upload$").test(arg.pathname), "/resources/image/upload"));
           sinon.assert.calledWith(request, sinon.match(arg => "DELETE" === arg.method, "DELETE"));
           sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('keep_original', 'true'), "keep_original=true"));
-          return sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('all', 'true'), "all=true"));
+          sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('all', 'true'), "all=true"));
         });
       });
     });
@@ -695,13 +695,13 @@ describe("api", function() {
         return xhr.restore();
       });
       it("should support changing moderation status with notification-url", function() {
-        cloudinary.v2.api.update("sample", {
+        return cloudinary.v2.api.update("sample", {
           moderation_status: "approved",
           notification_url: "http://example.com"
         });
         if (writeSpy.called) {
           sinon.assert.calledWith(writeSpy, sinon.match(/notification_url=http%3A%2F%2Fexample.com/));
-          return sinon.assert.calledWith(writeSpy, sinon.match(/moderation_status=approved/));
+          sinon.assert.calledWith(writeSpy, sinon.match(/moderation_status=approved/));
         }
       });
     });
@@ -771,7 +771,7 @@ describe("api", function() {
         public_id: helper.TEST_TAG,
         tags: [...helper.UPLOAD_TAGS, 'access_control_test']
       };
-      return it("should allow the user to define ACL in the update parameters2", function() {
+      it("should allow the user to define ACL in the update parameters2", function() {
         return helper.mockPromise((xhr, writeSpy, requestSpy) => {
           options.access_control = [acl];
           cloudinary.v2.api.update("id", options);
@@ -935,7 +935,7 @@ describe("api", function() {
         tags: UPLOAD_TAGS.concat([publishTestTag])
       }).then(result => {
         publishTestId = result.public_id;
-        return idsToDelete.push(publishTestId);
+        idsToDelete.push(publishTestId);
       });
     });
     after(function() {
@@ -976,7 +976,7 @@ describe("api", function() {
         expect(published[0].url).to.match(/\/upload\//);
       });
     });
-    return it("should return empty when explicit given type doesn't match resource", function() {
+    it("should return empty when explicit given type doesn't match resource", function() {
       this.timeout(helper.TIMEOUT_LONG);
       return cloudinary.v2.api.publish_by_ids([publishTestId], {
         type: "private"
@@ -1021,7 +1021,7 @@ describe("api", function() {
         expect(resource.public_id).to.be(publicId);
         expect(resource.access_mode).to.be('public');
       }));
-    return it("should update access mode by tag", ()=>
+    it("should update access mode by tag", ()=>
       cloudinary.v2.api.update_resources_access_mode_by_tag("public", access_mode_tag).then(result => {
         var resource;
         expect(result.updated).to.be.an('array');

--- a/test/cache_spec.js
+++ b/test/cache_spec.js
@@ -28,14 +28,14 @@ var cache;
 
 describe("Cache", function () {
   before(function () {
-    return Cache.setAdapter(new KeyValueCacheAdapter(new FileKeyValueStorage()));
+    Cache.setAdapter(new KeyValueCacheAdapter(new FileKeyValueStorage()));
   });
   it("should be initialized", function () {
-    return expect(Cache).to.be.ok();
+    expect(Cache).to.be.ok();
   });
   it("should set and get a value", function () {
     Cache.set(PUBLIC_ID, {}, BREAKPOINTS);
-    return expect(Cache.get(PUBLIC_ID, {})).to.eql(BREAKPOINTS);
+    expect(Cache.get(PUBLIC_ID, {})).to.eql(BREAKPOINTS);
   });
   describe("Upload integration", function () {
     this.timeout(helper.TIMEOUT_LONG);
@@ -65,7 +65,7 @@ describe("Cache", function () {
         expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
       }
       if (!cloudinary.config().keep_test_products) {
-        return cloudinary.api.delete_resources_by_tag(helper.TEST_TAG);
+        cloudinary.api.delete_resources_by_tag(helper.TEST_TAG);
       }
     });
     it("should save responsive breakpoints to cache after upload", function () {

--- a/test/search_spec.js
+++ b/test/search_spec.js
@@ -114,7 +114,7 @@ describe("search_api", function () {
         if (!(config.api_key && config.api_secret)) {
           expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
         }
-        return cloudinary.v2.api.delete_resources_by_tag(SEARCH_TAG);
+        cloudinary.v2.api.delete_resources_by_tag(SEARCH_TAG);
       }
     });
     it(`should return all images tagged with ${SEARCH_TAG}`, function () {
@@ -159,7 +159,7 @@ describe("search_api", function () {
         .then(function (results) {
           expect(results['resources'].length).to.eql(3);
           results['resources'].forEach(function (res) {
-            return expect(Object.keys(res['context'])).to.eql(['stage']);
+            expect(Object.keys(res['context'])).to.eql(['stage']);
           });
         });
     });

--- a/test/source_tag_spec.js
+++ b/test/source_tag_spec.js
@@ -40,7 +40,7 @@ describe('source helper', function () {
     };
     fill_transformation_str = `c_fill,h_${max_width},w_${max_width}`;
     cloudinary.config(true); // Reset
-    return cloudinary.config({
+    cloudinary.config({
       cloud_name: "test123",
       api_secret: "1234"
     });

--- a/test/streaming_profiles_spec.js
+++ b/test/streaming_profiles_spec.js
@@ -25,13 +25,13 @@ describe('Cloudinary::Api', function () {
   after(function (done) {
     var config = cloudinary.config(true);
     if (cloudinary.config().keep_test_products) {
-      return done();
+      done();
     } else {
       if (!(config.api_key && config.api_secret)) {
         expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
       }
       Q.allSettled([cloudinary.v2.api.delete_streaming_profile(test_id_1), cloudinary.v2.api.delete_streaming_profile(test_id_1 + 'a'), cloudinary.v2.api.delete_streaming_profile(test_id_3)]).finally(function () {
-        return done();
+        done();
       });
       return true;
     }

--- a/test/uploader_spec.js
+++ b/test/uploader_spec.js
@@ -48,7 +48,7 @@ describe("uploader", function() {
     ]);
   });
   beforeEach(function() {
-    return cloudinary.config(true);
+    cloudinary.config(true);
   });
   it("should successfully upload file", function() {
     this.timeout(helper.TIMEOUT_LONG);
@@ -245,16 +245,16 @@ describe("uploader", function() {
         version: result.version
       }, cloudinary.config().api_secret);
       expect(result.signature).to.eql(expected_signature);
-      return done();
+      done();
     });
     file_reader = fs.createReadStream(IMAGE_FILE, {
       encoding: 'binary'
     });
     file_reader.on('data', function(chunk) {
-      return stream.write(chunk, 'binary');
+      stream.write(chunk, 'binary');
     });
-    return file_reader.on('end', function() {
-      return stream.end();
+    file_reader.on('end', function() {
+      stream.end();
     });
   });
   describe("tags", function() {
@@ -321,7 +321,7 @@ describe("uploader", function() {
     before(function() {
       return Q.all([uploadImage(), uploadImage()]).spread(function(result1, result2) {
         first_id = result1.public_id;
-        return second_id = result2.public_id;
+        second_id = result2.public_id;
       });
     });
     it("should add context to existing resources", function() {
@@ -486,6 +486,7 @@ describe("uploader", function() {
     });
   });
   it("should support requesting manual moderation", function() {
+    this.timeout(helper.TIMEOUT_LONG);
     return cloudinary.v2.uploader.upload(IMAGE_FILE, {
       moderation: "manual",
       tags: UPLOAD_TAGS
@@ -564,55 +565,51 @@ describe("uploader", function() {
           tags: UPLOAD_TAGS
         }, function(error, result) {
           if (error != null) {
-            return done(new Error(error.message));
+            done(new Error(error.message));
           }
           expect(result.bytes).to.eql(stat.size);
           expect(result.etag).to.eql("4c13724e950abcb13ec480e10f8541f5");
           return done();
         });
-        return true;
       });
     });
     it("should return error if value is less than 5MB", function(done) {
-      return fs.stat(LARGE_RAW_FILE, function(err, stat) {
+      fs.stat(LARGE_RAW_FILE, function(err, stat) {
         cloudinary.v2.uploader.upload_large(LARGE_RAW_FILE, {
           chunk_size: 40000,
           tags: UPLOAD_TAGS
         }, function(error, result) {
           expect(error.message).to.eql("All parts except EOF-chunk must be larger than 5mb");
-          return done();
+          done();
         });
-        return true;
       });
     });
     it("should support uploading a small raw file", function(done) {
-      return fs.stat(RAW_FILE, function(err, stat) {
+      fs.stat(RAW_FILE, function(err, stat) {
         cloudinary.v2.uploader.upload_large(RAW_FILE, {
           tags: UPLOAD_TAGS
         }, function(error, result) {
           if (error != null) {
-            return done(new Error(error.message));
+            done(new Error(error.message));
           }
           expect(result.bytes).to.eql(stat.size);
           expect(result.etag).to.eql("ffc265d8d1296247972b4d478048e448");
-          return done();
+          done();
         });
-        return true;
       });
     });
     it("should support uploading a small image file", function(done) {
-      return fs.stat(IMAGE_FILE, function(err, stat) {
-        cloudinary.v2.uploader.upload_chunked(IMAGE_FILE, {
+      fs.stat(IMAGE_FILE, function(err, stat) {
+        return cloudinary.v2.uploader.upload_chunked(IMAGE_FILE, {
           tags: UPLOAD_TAGS
         }, function(error, result) {
           if (error != null) {
-            return done(new Error(error.message));
+            done(new Error(error.message));
           }
           expect(result.bytes).to.eql(stat.size);
           expect(result.etag).to.eql("7dc60722d4653261648038b579fdb89e");
-          return done();
+          done();
         });
-        return true;
       });
     });
     it("should support uploading large video files", function() {
@@ -640,10 +637,10 @@ describe("uploader", function() {
         expect(timestamps.length).to.be.greaterThan(1);
         expect(uniq(timestamps)).to.eql(uniq(timestamps)); // uniq b/c last timestamp may be duplicated
       }).finally(function() {
-        return writeSpy.restore();
+        writeSpy.restore();
       });
     });
-    it("should update timestamp for each chuck", function() {
+    it("should update timestamp for each chunk", function() {
       var writeSpy = sinon.spy(ClientRequest.prototype, 'write');
       return Q.denodeify(cloudinary.v2.uploader.upload_chunked)(LARGE_VIDEO, {
         chunk_size: 6000000,
@@ -661,7 +658,7 @@ describe("uploader", function() {
         expect(timestamps.length).to.be.greaterThan(1);
         expect(uniq(timestamps)).to.eql(uniq(timestamps));
       }).finally(function() {
-        return writeSpy.restore();
+        writeSpy.restore();
       });
     });
     it("should support uploading based on a url", function(done) {
@@ -670,28 +667,28 @@ describe("uploader", function() {
         tags: UPLOAD_TAGS
       }, function(error, result) {
         if (error != null) {
-          return done(new Error(error.message));
+          done(new Error(error.message));
         }
         expect(result.etag).to.eql("7dc60722d4653261648038b579fdb89e");
-        return done();
+        done();
       });
-      return true;
     });
   });
   it("should support unsigned uploading using presets", function() {
     this.timeout(helper.TIMEOUT_LONG);
+    let presetName;
     return cloudinary.v2.api.create_upload_preset({
       folder: "upload_folder",
       unsigned: true,
       tags: UPLOAD_TAGS
     }).then(function(preset) {
+      presetName = preset.name;
       return cloudinary.v2.uploader.unsigned_upload(IMAGE_FILE, preset.name, {
         tags: UPLOAD_TAGS
-      }).then(function(result) {
-        return [preset.name, result.public_id];
       });
-    }).then(function([presetName, public_id]) {
+    }).then(function({public_id}) {
       expect(public_id).to.match(/^upload_folder\/[a-z0-9]+$/);
+    }).finally(function() {
       return cloudinary.v2.api.delete_upload_preset(presetName);
     });
   });
@@ -718,10 +715,10 @@ describe("uploader", function() {
         version: result.version
       }, cloudinary.config().api_secret);
       expect(result.signature).to.eql(expected_signature);
-      return done();
+      done();
     });
     file_reader = fs.createReadStream(IMAGE_FILE);
-    return file_reader.pipe(upload);
+    file_reader.pipe(upload);
   });
   it("should fail with http.Agent (non secure)", function() {
     this.timeout(helper.TIMEOUT_LONG);
@@ -745,12 +742,12 @@ describe("uploader", function() {
       expect(result.signature).to.eql(expected_signature);
     });
     file_reader = fs.createReadStream(IMAGE_FILE);
-    return file_reader.pipe(upload);
+    file_reader.pipe(upload);
   });
   context(":responsive_breakpoints", function() {
-    return context(":create_derived with different transformation settings", function() {
+    context(":create_derived with different transformation settings", function() {
       before(function() {
-        return helper.setupCache();
+        helper.setupCache();
       });
       it('should return a responsive_breakpoints in the response', function() {
         return cloudinary.v2.uploader.upload(IMAGE_FILE, {
@@ -786,7 +783,7 @@ describe("uploader", function() {
           expect(at(result, "responsive_breakpoints[0].breakpoints[0].url")[0]).to.match(/\.jpg$/);
           expect(at(result, "responsive_breakpoints[1].transformation")[0]).to.eql("a_10");
           expect(at(result, "responsive_breakpoints[1].breakpoints[0].url")[0]).to.match(/\.gif$/);
-          return result.responsive_breakpoints.map(function(bp) {
+          result.responsive_breakpoints.map(function(bp) {
             var cached, format;
             format = path.extname(bp.breakpoints[0].url).slice(1);
             cached = cloudinary.Cache.get(result.public_id, {
@@ -795,7 +792,7 @@ describe("uploader", function() {
             });
             expect(cached).to.be.ok();
             expect(cached.length).to.be(bp.breakpoints.length);
-            return bp.breakpoints.forEach(function(o) {
+            bp.breakpoints.forEach(function(o) {
               expect(cached).to.contain(o.width);
             });
           });
@@ -812,7 +809,7 @@ describe("uploader", function() {
           effect: "sepia"
         }
       });
-      return sinon.assert.calledWith(mocked.write, sinon.match(helper.uploadParamMatcher("async", 1)));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.uploadParamMatcher("async", 1)));
     });
   });
   describe("explicit", function() {
@@ -850,7 +847,7 @@ describe("uploader", function() {
         raw_convert: "google_speech",
         tags: [TEST_TAG]
       });
-      return sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('raw_convert', 'google_speech')));
+      sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('raw_convert', 'google_speech')));
     });
   });
   it("should create an image upload tag with required properties", function() {
@@ -881,14 +878,14 @@ describe("uploader", function() {
     beforeEach(function() {
       writeSpy = sinon.spy(ClientRequest.prototype, 'write');
       requestSpy = sinon.spy(http, 'request');
-      return options = {
+      options = {
         public_id: helper.TEST_TAG,
         tags: [...helper.UPLOAD_TAGS, 'access_control_test']
       };
     });
     afterEach(function() {
       requestSpy.restore();
-      return writeSpy.restore();
+      writeSpy.restore();
     });
     acl = {
       access_type: 'anonymous',

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -30,7 +30,7 @@ describe("utils", function () {
     }
   });
   afterEach(function () {
-    return cloudinary.config(defaults({
+    cloudinary.config(defaults({
       secure: null
     }, this.orig));
   });
@@ -45,7 +45,7 @@ describe("utils", function () {
     });
     this.orig = clone(this.cfg);
     cloud_name = cloudinary.config("cloud_name");
-    return root_path = `http://res.cloudinary.com/${cloud_name}`;
+    root_path = `http://res.cloudinary.com/${cloud_name}`;
   });
   find_by_attr = function (elements, attr, value) {
     var element, i, len;
@@ -58,56 +58,56 @@ describe("utils", function () {
     return void 0;
   };
   it("should use cloud_name from config", function () {
-    return test_cloudinary_url("test", {}, `http://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
+    test_cloudinary_url("test", {}, `http://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
   });
   it("should allow overriding cloud_name in options", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       cloud_name: "test321"
     }, "http://res.cloudinary.com/test321/image/upload/test", {});
   });
   it("should use default secure distribution if secure=true", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       secure: true
     }, `https://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
   });
   it("should allow overriding secure distribution if secure=true", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       secure: true,
       secure_distribution: "something.else.com"
     }, `https://something.else.com/${cloud_name}/image/upload/test`, {});
   });
   it("should take secure distribution from config if secure=true", function () {
     cloudinary.config("secure_distribution", "config.secure.distribution.com");
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       secure: true
     }, `https://config.secure.distribution.com/${cloud_name}/image/upload/test`, {});
   });
   it("should default to akamai if secure is given with private_cdn and no secure_distribution", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       secure: true,
       private_cdn: true
     }, `https://${cloud_name}-res.cloudinary.com/image/upload/test`, {});
   });
   it("should not add cloud_name if secure private_cdn and secure non akamai secure_distribution", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       secure: true,
       private_cdn: true,
       secure_distribution: "something.cloudfront.net"
     }, "https://something.cloudfront.net/image/upload/test", {});
   });
   it("should allow overriding private_cdn if private_cdn=true", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       private_cdn: true
     }, `http://${cloud_name}-res.cloudinary.com/image/upload/test`, {});
   });
   it("should allow overriding private_cdn if private_cdn=false", function () {
     cloudinary.config("private_cdn", true);
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       private_cdn: false
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
   });
   it("should allow overriding cname if cname=example.com", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       cname: "example.com"
     }, `http://example.com/${cloud_name}/image/upload/test`, {});
   });
@@ -116,10 +116,10 @@ describe("utils", function () {
     test_cloudinary_url("test", {
       cname: false
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
-    return cloudinary.config("cname", null);
+    cloudinary.config("cname", null);
   });
   it("should use format from options", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       format: 'jpg'
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/test.jpg`, {});
   });
@@ -127,14 +127,14 @@ describe("utils", function () {
     test_cloudinary_url("test", {
       url_suffix: "hello"
     }, `http://res.cloudinary.com/${cloud_name}/images/test/hello`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       angle: 0
     }, `http://res.cloudinary.com/${cloud_name}/images/a_0/test/hello`, {});
   });
   it("should disallow url_suffix in non upload types", function () {
     expect(function () {
-      return utils.url("test", {
+      utils.url("test", {
         url_suffix: "hello",
         private_cdn: true,
         type: 'facebook'
@@ -143,13 +143,13 @@ describe("utils", function () {
   });
   it("should disallow url_suffix with / or .", function () {
     expect(function () {
-      return utils.url("test", {
+      utils.url("test", {
         url_suffix: "hello/world",
         private_cdn: true
       });
     }).to.be.throwError(/url_suffix should not include . or \//);
     expect(function () {
-      return utils.url("test", {
+      utils.url("test", {
         url_suffix: "hello.world",
         private_cdn: true
       });
@@ -160,14 +160,14 @@ describe("utils", function () {
       url_suffix: "hello",
       private_cdn: true
     }, `http://${cloud_name}-res.cloudinary.com/images/test/hello`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       angle: 0,
       private_cdn: true
     }, `http://${cloud_name}-res.cloudinary.com/images/a_0/test/hello`, {});
   });
   it("should put format after url_suffix", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       private_cdn: true,
       format: "jpg"
@@ -189,7 +189,7 @@ describe("utils", function () {
       angle: 0,
       sign_url: true
     }).match(/s--[0-9A-Za-z_-]{8}--/).toString();
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       private_cdn: true,
       format: "jpg",
@@ -202,27 +202,27 @@ describe("utils", function () {
       format: "jpg",
       sign_url: true
     }).match(/s--[0-9A-Za-z_-]{8}--/).toString();
-    return test_cloudinary_url("%25a%20(b)", {
+    test_cloudinary_url("%25a%20(b)", {
       format: "jpg",
       sign_url: true
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/${expected_signature}/%25a%20(b).jpg`, {});
   });
   it("should support url_suffix for raw uploads", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       private_cdn: true,
       resource_type: 'raw'
     }, `http://${cloud_name}-res.cloudinary.com/files/test/hello`, {});
   });
   it("should support url_suffix for video uploads", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       private_cdn: true,
       resource_type: 'video'
     }, `http://${cloud_name}-res.cloudinary.com/videos/test/hello`, {});
   });
   it("should support url_suffix for authenticated uploads", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       url_suffix: "hello",
       private_cdn: true,
       type: 'authenticated'
@@ -233,7 +233,7 @@ describe("utils", function () {
       use_root_path: true,
       private_cdn: false
     }, `http://res.cloudinary.com/${cloud_name}/test`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       use_root_path: true,
       private_cdn: false,
       angle: 0
@@ -244,14 +244,14 @@ describe("utils", function () {
       use_root_path: true,
       private_cdn: true
     }, `http://${cloud_name}-res.cloudinary.com/test`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       use_root_path: true,
       private_cdn: true,
       angle: 0
     }, `http://${cloud_name}-res.cloudinary.com/a_0/test`, {});
   });
   it("should support use_root_path together with url_suffix for private_cdn", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       use_root_path: true,
       url_suffix: "hello",
       private_cdn: true
@@ -259,14 +259,14 @@ describe("utils", function () {
   });
   it("should disllow use_root_path if not image/upload", function () {
     expect(function () {
-      return utils.url("test", {
+      utils.url("test", {
         use_root_path: true,
         private_cdn: true,
         type: 'facebook'
       });
     }).to.be.throwError(/Root path only supported for image\/upload/);
     expect(function () {
-      return utils.url("test", {
+      utils.url("test", {
         use_root_path: true,
         private_cdn: true,
         resource_type: 'raw'
@@ -274,7 +274,7 @@ describe("utils", function () {
     }).to.be.throwError(/Root path only supported for image\/upload/);
   });
   it("should use width and height from options only if crop is given", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       width: 100,
       height: 100,
       crop: 'crop'
@@ -284,7 +284,7 @@ describe("utils", function () {
     });
   });
   it("should support initial width and height", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       width: "iw",
       height: "ih",
       crop: 'crop'
@@ -294,7 +294,7 @@ describe("utils", function () {
     });
   });
   it("should not pass width and height to html in case angle was used", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       width: 100,
       height: 100,
       crop: 'scale',
@@ -310,7 +310,7 @@ describe("utils", function () {
       quality: 0.4,
       prefix: "a"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/g_center,p_a,q_0.4,r_3,x_1,y_2/test`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       gravity: 'auto',
       crop: "crop",
       width: "0.5"
@@ -327,7 +327,7 @@ describe("utils", function () {
         width: 100,
         height: 100
       });
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         width: 100,
         height: 100,
         crop: 'crop',
@@ -338,8 +338,8 @@ describe("utils", function () {
       });
     });
     it("should support focal gravity", function () {
-      return ["adv_face", "adv_faces", "adv_eyes", "face", "faces", "body", "no_faces"].map(function (focal) {
-        return test_cloudinary_url("test", {
+      ["adv_face", "adv_faces", "adv_eyes", "face", "faces", "body", "no_faces"].map(function (focal) {
+        test_cloudinary_url("test", {
           width: 100,
           height: 100,
           crop: 'crop',
@@ -351,7 +351,7 @@ describe("utils", function () {
       });
     });
     it("should support auto level with thumb cropping", function () {
-      return [0, 10, 100].map(function (level) {
+      [0, 10, 100].map(function (level) {
         test_cloudinary_url("test", {
           width: 100,
           height: 100,
@@ -361,7 +361,7 @@ describe("utils", function () {
           width: 100,
           height: 100
         });
-        return test_cloudinary_url("test", {
+        test_cloudinary_url("test", {
           width: 100,
           height: 100,
           crop: 'thumb',
@@ -373,7 +373,7 @@ describe("utils", function () {
       });
     });
     it("should support custom_no_override", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         width: 100,
         height: 100,
         crop: 'crop',
@@ -386,17 +386,17 @@ describe("utils", function () {
   });
   describe("transformation", function () {
     it("should support named transformation", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         transformation: "blip"
       }, `http://res.cloudinary.com/${cloud_name}/image/upload/t_blip/test`, {});
     });
     it("should support array of named transformations", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         transformation: ["blip", "blop"]
       }, `http://res.cloudinary.com/${cloud_name}/image/upload/t_blip.blop/test`, {});
     });
     it("should support base transformation", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         transformation: {
           x: 100,
           y: 100,
@@ -409,7 +409,7 @@ describe("utils", function () {
       });
     });
     it("should support array of base transformations", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         transformation: [
           {
             x: 100,
@@ -442,7 +442,7 @@ describe("utils", function () {
       expect(result).to.eql("c_fill,w_200,x_100,y_100/r_10");
     });
     it("should not include empty transformations", function () {
-      return test_cloudinary_url("test", {
+      test_cloudinary_url("test", {
         transformation: [
           {},
           {
@@ -456,7 +456,7 @@ describe("utils", function () {
     });
   });
   it("should support size", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       size: "10x10",
       crop: 'crop'
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/c_crop,h_10,w_10/test`, {
@@ -465,12 +465,12 @@ describe("utils", function () {
     });
   });
   it("should use type from options", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       type: 'facebook'
     }, `http://res.cloudinary.com/${cloud_name}/image/facebook/test`, {});
   });
   it("should use resource_type from options", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       resource_type: 'raw'
     }, `http://res.cloudinary.com/${cloud_name}/raw/upload/test`, {});
   });
@@ -478,17 +478,17 @@ describe("utils", function () {
     test_cloudinary_url("http://test", {
       type: null
     }, "http://test", {});
-    return test_cloudinary_url("http://test", {
+    test_cloudinary_url("http://test", {
       type: "fetch"
     }, `http://res.cloudinary.com/${cloud_name}/image/fetch/http://test`, {});
   });
   it("should escape fetch urls", function () {
-    return test_cloudinary_url("http://blah.com/hello?a=b", {
+    test_cloudinary_url("http://blah.com/hello?a=b", {
       type: "fetch"
     }, `http://res.cloudinary.com/${cloud_name}/image/fetch/http://blah.com/hello%3Fa%3Db`, {});
   });
   it("should should escape http urls", function () {
-    return test_cloudinary_url("http://www.youtube.com/watch?v=d9NF2edxy-M", {
+    test_cloudinary_url("http://www.youtube.com/watch?v=d9NF2edxy-M", {
       type: "youtube"
     }, `http://res.cloudinary.com/${cloud_name}/image/youtube/http://www.youtube.com/watch%3Fv%3Dd9NF2edxy-M`, {});
   });
@@ -496,12 +496,12 @@ describe("utils", function () {
     test_cloudinary_url("test", {
       background: "red"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/b_red/test`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       background: "#112233"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/b_rgb:112233/test`, {});
   });
   it("should support default_image", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       default_image: "default"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/d_default/test`, {});
   });
@@ -509,30 +509,30 @@ describe("utils", function () {
     test_cloudinary_url("test", {
       angle: "55"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/a_55/test`, {});
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       angle: ["auto", "55"]
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/a_auto.55/test`, {});
   });
   it("should support format for fetch urls", function () {
-    return test_cloudinary_url("http://cloudinary.com/images/logo.png", {
+    test_cloudinary_url("http://cloudinary.com/images/logo.png", {
       format: "jpg",
       type: "fetch"
     }, `http://res.cloudinary.com/${cloud_name}/image/fetch/f_jpg/http://cloudinary.com/images/logo.png`, {});
   });
   it("should support effect", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       effect: "sepia"
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/e_sepia/test`, {});
   });
   it("should support effect with hash param", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       effect: {
         sepia: -10
       }
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/e_sepia:-10/test`, {});
   });
   it("should support effect with array param", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       effect: ["sepia", 10]
     }, `http://res.cloudinary.com/${cloud_name}/image/upload/e_sepia:10/test`, {});
   });
@@ -657,7 +657,7 @@ describe("utils", function () {
       });
     });
     beforeEach(function () {
-      return options = merge({
+      options = merge({
         version: authenticated_image['version'],
         sign_url: true,
         type: "authenticated"
@@ -702,21 +702,21 @@ describe("utils", function () {
       });
       fileName = `${os.tmpdir()}/test_subtitles.srt`;
       srt = "1\n00:00:10,500 --> 00:00:13,000\nHello World, Nice to meet you?\n";
-      return fs.writeFile(fileName, srt, function (error) {
+      fs.writeFile(fileName, srt, function (error) {
         if (error != null) {
-          return done(new Error(error.message));
+          done(new Error(error.message));
         }
         cloudinary.v2.config(true);
-        return cloudinary.v2.uploader.upload(fileName, {
+        cloudinary.v2.uploader.upload(fileName, {
           public_id: 'subtitles.srt',
           resource_type: 'raw',
           overwrite: true,
           tags: TEST_TAG
         }, function (error, result) {
           if (error != null) {
-            return done(new Error(error.message));
+            done(new Error(error.message));
           }
-          return done();
+          done();
         });
       });
     });
@@ -806,7 +806,7 @@ describe("utils", function () {
     });
   });
   it("should use ssl_detected if secure is not given as parameter and not set to true in configuration", function () {
-    return test_cloudinary_url("test", {
+    test_cloudinary_url("test", {
       ssl_detected: true
     }, `https://res.cloudinary.com/${cloud_name}/image/upload/test`, {});
   });
@@ -1015,14 +1015,14 @@ describe("utils", function () {
     var configBck = void 0;
     before(function () {
       configBck = cloudinary.config();
-      return cloudinary.config({
+      cloudinary.config({
         cloud_name: 'test123',
         api_key: "1234",
         api_secret: "b"
       });
     });
     after(function () {
-      return cloudinary.config(configBck);
+      cloudinary.config(configBck);
     });
     it("should correctly sign URLs", function () {
       test_cloudinary_url("image.jpg", {
@@ -1128,7 +1128,7 @@ describe("utils", function () {
     });
     sig = cloudinary.utils.webhook_signature(data, timestamp);
     expect(sig).to.eql('bac927006d3ce039ef7632e2c03189348d02924a');
-    return cloudinary.config(orig);
+    cloudinary.config(orig);
   });
   describe('Conditional Transformation', function () {
     var configBck = null;
@@ -1139,10 +1139,10 @@ describe("utils", function () {
         api_key: "1234",
         api_secret: "b"
       });
-      return cloud_name = 'test123';
+      cloud_name = 'test123';
     });
     after(function () {
-      return cloudinary.config(configBck);
+      cloudinary.config(configBck);
     });
     describe('with literal condition string', function () {
       it("should include the if parameter as the first component in the transformation string", function () {

--- a/test/video_spec.js
+++ b/test/video_spec.js
@@ -10,7 +10,7 @@ describe("video tag helper", function () {
   DEFAULT_UPLOAD_PATH = "http://res.cloudinary.com/test123/image/upload/";
   beforeEach(function () {
     cloudinary.config(true); // Reset
-    return cloudinary.config({
+    cloudinary.config({
       cloud_name: "test123",
       api_secret: "1234"
     });


### PR DESCRIPTION
Remove unnecessary 'return' statements
Remove unused calls to API and config in `access_control_spec.js`