### PR TITLE
Add support for 'delete folder' API

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -458,6 +458,14 @@ exports.sub_folders = function sub_folders(path, callback) {
   return call_api("get", uri, {}, callback, options);
 };
 
+exports.delete_folder = function delete_folder(path, callback) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  var uri = void 0;
+  uri = ["folders", path];
+  return call_api("delete", uri, {}, callback, options);
+};
+
 exports.upload_mappings = function upload_mappings(callback) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 

--- a/lib-es5/v2/api.js
+++ b/lib-es5/v2/api.js
@@ -33,6 +33,7 @@ v1_adapters(exports, api, {
   create_upload_preset: 0,
   root_folders: 0,
   sub_folders: 1,
+  delete_folder: 1,
   upload_mappings: 0,
   upload_mapping: 1,
   delete_upload_mapping: 1,

--- a/lib/api.js
+++ b/lib/api.js
@@ -366,6 +366,12 @@ exports.sub_folders = function sub_folders(path, callback, options = {}) {
   return call_api("get", uri, {}, callback, options);
 };
 
+exports.delete_folder = function delete_folder(path, callback, options = {}) {
+  let uri;
+  uri = ["folders", path];
+  return call_api("delete", uri, {}, callback, options);
+};
+
 exports.upload_mappings = function upload_mappings(callback, options = {}) {
   let params;
   params = only(options, "next_cursor", "max_results");

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -31,6 +31,7 @@ v1_adapters(exports, api, {
   create_upload_preset: 0,
   root_folders: 0,
   sub_folders: 1,
+  delete_folder: 1,
   upload_mappings: 0,
   upload_mapping: 1,
   delete_upload_mapping: 1,

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -892,6 +892,31 @@ describe("api", function () {
       expect().fail('error test_folder_not_exists should not pass to "then" handler but "catch"');
     }).catch(({ error }) => expect(error.message).to.eql('Can\'t find folder with path test_folder_not_exists'));
   });
+  describe("delete folders", function() {
+    this.timeout(helper.TIMEOUT_MEDIUM);
+    const folderPath= "test_folder/delete_folder/"+TEST_TAG;
+    before(function(){
+      return cloudinary.v2.uploader.upload(IMAGE_FILE, {
+        folder: folderPath,
+        tags: UPLOAD_TAGS
+      }).delay(2 * 1000).then(function() {
+        return cloudinary.v2.api.delete_resources_by_prefix(folderPath)
+          .then(() => cloudinary.v2.api.sub_folders(folderPath).then(folder => {
+            expect(folder).not.to.be(null);
+            expect(folder["total_count"]).to.eql(0);
+            expect(folder["folders"]).to.be.empty;
+        }));
+      });
+    });
+    it('should delete an empty folder', function () {
+      this.timeout(helper.TIMEOUT_MEDIUM);
+      return cloudinary.v2.api.delete_folder(
+        folderPath
+      ).delay(2 * 1000).then(() => cloudinary.v2.api.sub_folders(folderPath)
+      ).then(()=> expect().fail()
+      ).catch(({error}) => expect(error.message).to.contain("Can't find folder with path"));
+    });
+  });
   describe('.restore', function () {
     this.timeout(helper.TIMEOUT_MEDIUM);
 


### PR DESCRIPTION
Add SDK support for the 'delete folder' API, which permits deletion of empty folders.
Add tests for the delete folder method

Example Usage:

    cloudinary.v2.api.delete_folder("temp", function(error, result){console.log(result)});