### PR TITLE
Escape quotes in HTML attributes (NodeJS)

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1163,7 +1163,7 @@ function join_pair(key, value) {
 
 /**
  * If the given value is a string, replaces single or double quotes with character entities
- *
+ * @private
  * @param {*} value The string to encode quotes in
  * @returns {*} Encoded string or original value if not a string
  */

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1165,7 +1165,7 @@ function join_pair(key, value) {
  * If the given value is a string, replaces single or double quotes with character entities
  * @private
  * @param {*} value The string to encode quotes in
- * @returns {*} Encoded string or original value if not a string
+ * @return {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
   return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1162,12 +1162,13 @@ function join_pair(key, value) {
 }
 
 /**
- * If given value is a string, replaces quotes with character entities (&#34;, &#39;)
- * @param value - value to change
- * @returns {*} changed value
+ * If the given value is a string, replaces single or double quotes with character entities
+ *
+ * @param {*} value The string to encode quotes in
+ * @returns {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
-    return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+  return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
 }
 
 /**

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1162,13 +1162,22 @@ function join_pair(key, value) {
 }
 
 /**
+ * If given value is a string, replaces quotes with character entities (&#34;, &#39;)
+ * @param value - value to change
+ * @returns {*} changed value
+ */
+function escapeQuotes(value) {
+    return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+}
+
+/**
  *
  * @param attrs
  * @return {*}
  */
 exports.html_attrs = function html_attrs(attrs) {
   return filter(map(attrs, function (value, key) {
-    return join_pair(key, value);
+    return join_pair(key, escapeQuotes(value));
   })).sort().join(" ");
 };
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1116,12 +1116,13 @@ function join_pair(key, value) {
 }
 
 /**
- * If given value is a string, replaces quotes with character entities (&#34;, &#39;)
- * @param value - value to change
- * @returns {*} changed value
+ * If the given value is a string, replaces single or double quotes with character entities
+ *
+ * @param {*} value The string to encode quotes in
+ * @returns {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
-    return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+  return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1116,13 +1116,22 @@ function join_pair(key, value) {
 }
 
 /**
+ * If given value is a string, replaces quotes with character entities (&#34;, &#39;)
+ * @param value - value to change
+ * @returns {*} changed value
+ */
+function escapeQuotes(value) {
+    return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+}
+
+/**
  *
  * @param attrs
  * @return {*}
  */
 exports.html_attrs = function html_attrs(attrs) {
   return filter(map(attrs, function(value, key) {
-    return join_pair(key, value);
+    return join_pair(key, escapeQuotes(value));
   })).sort().join(" ");
 };
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1119,7 +1119,7 @@ function join_pair(key, value) {
  * If the given value is a string, replaces single or double quotes with character entities
  * @private
  * @param {*} value The string to encode quotes in
- * @returns {*} Encoded string or original value if not a string
+ * @return {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
   return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1117,7 +1117,7 @@ function join_pair(key, value) {
 
 /**
  * If the given value is a string, replaces single or double quotes with character entities
- *
+ * @private
  * @param {*} value The string to encode quotes in
  * @returns {*} Encoded string or original value if not a string
  */

--- a/test/image_spec.js
+++ b/test/image_spec.js
@@ -105,6 +105,11 @@ describe('image helper', function() {
     tag = cloudinary.image('sample.jpg', options);
     expect(tag).to.contain("alt='updated alt'");
   });
+  it("should escape quotes in html attributes", function() {
+    expect(cloudinary.image("sample.jpg", {
+      alt: "asdfg\"'asdf"
+    })).to.eql(`<img src='${UPLOAD_PATH}/sample.jpg' alt='asdfg&#34;&#39;asdf'/>`);
+  });
   sharedExamples("client_hints", function(options) {
     it("should not use data-src or set responsive class", function() {
       var tag = cloudinary.image('sample.jpg', options);


### PR DESCRIPTION
When creating an HTML tag encodes quotes inside attributes using HTML entities.

**Semantic nitpicking**: In all the SDKs this function is called `escapeQuotes` but what it actually does is encode quotes, not escape them. Renaming the functions should be relatively painless as this is an internal private function and should not affect the public API.