### PR TITLE
Add 'derived_next_resource' to api.resource method

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -233,7 +233,7 @@ exports.resource = function resource(public_id, callback) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, only(options, "exif", "colors", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
+  return call_api("get", uri, only(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -196,7 +196,7 @@ exports.resource = function resource(public_id, callback, options = {}) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, only(options, "exif", "colors", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
+  return call_api("get", uri, only(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback, options = {}) {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -306,6 +306,17 @@ describe("api", function () {
           expect(resource.derived).to.have.length(1);
         });
     });
+    describe("derived pagination", function(){
+      it("should send the derived_next_cursor to the server", function() {
+        return helper.mockPromise((xhr, writeSpy, requestSpy) => {
+          cloudinary.v2.api.resource(PUBLIC_ID, {derived_next_cursor: 'aaa'});
+          return sinon.assert.calledWith(
+            requestSpy, sinon.match(sinon.match({
+              query: sinon.match('derived_next_cursor=aaa')
+            }, 'derived_next_cursor=aaa')));
+        });
+      });
+    });
   });
   describe("delete", function () {
     it("should allow deleting derived resource", function () {


### PR DESCRIPTION
Allows pagination when accessing the details of a single resource and many derived versions exist

Unit test to verify the parameter is passed to the server when specified