### PR TITLE
Add `live` parameter support when creating and updating upload presets

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -428,7 +428,7 @@ exports.update_upload_preset = function update_upload_preset(name, callback) {
   var params = void 0,
       uri = void 0;
   uri = ["upload_presets", name];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id", "live"));
   return call_api("put", uri, params, callback, options);
 };
 
@@ -438,7 +438,7 @@ exports.create_upload_preset = function create_upload_preset(callback) {
   var params = void 0,
       uri = void 0;
   uri = ["upload_presets"];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id", "live"));
   return call_api("post", uri, params, callback, options);
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -343,14 +343,14 @@ exports.delete_upload_preset = function delete_upload_preset(name, callback, opt
 exports.update_upload_preset = function update_upload_preset(name, callback, options = {}) {
   let params, uri;
   uri = ["upload_presets", name];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id", "live"));
   return call_api("put", uri, params, callback, options);
 };
 
 exports.create_upload_preset = function create_upload_preset(callback, options = {}) {
   let params, uri;
   uri = ["upload_presets"];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id", "live"));
   return call_api("post", uri, params, callback, options);
 };
 

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -654,6 +654,7 @@ describe("api", function () {
             colors: true,
             unsigned: true,
             disallow_public_id: true,
+            live: true
           });
         var expectedPath="/.*\/upload_presets/"+API_TEST_UPLOAD_PRESET3+"$";
         sinon.assert.calledWith(request, sinon.match({
@@ -663,6 +664,19 @@ describe("api", function () {
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('colors', 1 , "colors=1")));
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('unsigned', true , "unsigned=true")));
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('disallow_public_id', true , "disallow_public_id=true")));
+        sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('live', true, "live=true")));
+      });
+    });
+    it("should allow creating upload_presets", function () {
+      return helper.mockPromise(function (xhr, write) {
+        cloudinary.v2.api.create_upload_preset({
+          folder: "upload_folder",
+          unsigned: true,
+          tags: UPLOAD_TAGS,
+          live: true
+        });
+        sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('unsigned', true, "unsigned=true")));
+        sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('live', true, "live=true")));
       });
     });
   });


### PR DESCRIPTION
Added support to:
* `update_upload_preset`
* `create_upload_preset`