### PR TITLE
Fix type definition of uploader.upload_stream and uploader.unsigned_upload_stream

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -820,7 +820,7 @@ declare module 'cloudinary' {
 
             function unsigned_upload(file: string, upload_preset: string, callback?: ErrorCallBack): Promise<any>;
 
-            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack, options?: UploadApiOptions): Promise<any>;
+            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack, options?: UploadApiOptions): NodeJS.ReadWriteStream;
 
             function upload(file: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
@@ -836,7 +836,7 @@ declare module 'cloudinary' {
 
             function upload_large(path: string, callback?: ErrorCallBack): Promise<any>;
 
-            function upload_stream(callback?: ErrorCallBack, options?: UploadApiOptions): Promise<any>;
+            function upload_stream(callback?: ErrorCallBack, options?: UploadApiOptions): NodeJS.ReadWriteStream;
 
             function upload_tag_params(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -819,8 +819,10 @@ declare module 'cloudinary' {
             function unsigned_upload(file: string, upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
             function unsigned_upload(file: string, upload_preset: string, callback?: ErrorCallBack): Promise<any>;
+            
+            function unsigned_upload_stream(upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): NodeJS.ReadWriteStream;
 
-            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack, options?: UploadApiOptions): NodeJS.ReadWriteStream;
+            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack): NodeJS.ReadWriteStream;
 
             function upload(file: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
@@ -836,7 +838,9 @@ declare module 'cloudinary' {
 
             function upload_large(path: string, callback?: ErrorCallBack): Promise<any>;
 
-            function upload_stream(callback?: ErrorCallBack, options?: UploadApiOptions): NodeJS.ReadWriteStream;
+            function upload_stream(options?: UploadApiOptions, callback?: ErrorCallBack): NodeJS.ReadWriteStream;
+
+            function upload_stream(callback?: ErrorCallBack): NodeJS.ReadWriteStream;
 
             function upload_tag_params(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -820,9 +820,7 @@ declare module 'cloudinary' {
 
             function unsigned_upload(file: string, upload_preset: string, callback?: ErrorCallBack): Promise<any>;
 
-            function unsigned_upload_stream(upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
-
-            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack): Promise<any>;
+            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack, options?: UploadApiOptions): Promise<any>;
 
             function upload(file: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
@@ -838,9 +836,7 @@ declare module 'cloudinary' {
 
             function upload_large(path: string, callback?: ErrorCallBack): Promise<any>;
 
-            function upload_stream(upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
-
-            function upload_stream(upload_preset: string, callback?: ErrorCallBack): Promise<any>;
+            function upload_stream(callback?: ErrorCallBack, options?: UploadApiOptions): Promise<any>;
 
             function upload_tag_params(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 


### PR DESCRIPTION
According to the implementation below this should be considered as an error.
https://github.com/cloudinary/cloudinary_npm/blob/b8b7f1a38e793d0a75e48529446e71ddd039933c/lib/uploader.js#L26-L37