### PR TITLE
fix: move typescript to devDependencies and update major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "main": "cloudinary.js",
   "dependencies": {
     "lodash": "^4.17.11",
-    "q": "^1.5.1",
-    "typescript": "^2.9.2"
+    "q": "^1.5.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -36,6 +35,7 @@
     "mocha": "^5.0.0",
     "nyc": "^13.3.0",
     "sinon": "^6.1.4",
+    "typescript": "^3.7.5",
     "webpack-cli": "^3.2.1"
   },
   "files": [


### PR DESCRIPTION
At the moment when trying to use cloudinary sdk in typescript project of one of latest version - build fails with a lot of errors. (I assume because of two different major versions of TS)

This PR:
* moves typescript to `devDependencies` where it should actually be
* upgrades typescript to latest major version