### PR TITLE
fix: type defs for stream upload methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "^2.9.2"
   },
   "devDependencies": {
+    "@types/node": "^13.5.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -764,7 +764,7 @@ cloudinary.v2.uploader.remove_tag('12', ['11'], function (err, res) {
     console.log(err, res);
 });
 
-// $ExpectType Promise<any>
+// $ExpectType UploadStream
 cloudinary.v2.uploader.upload_stream(
     {template: "http://www.example.com/images/"},
     function (error, result) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,6 @@
+import { Transform } from 'stream';
+
+
 declare module 'cloudinary' {
 
     /****************************** Constants *************************************/
@@ -531,6 +534,9 @@ declare module 'cloudinary' {
     type TargetArchiveFormat = string | "zip" | "tgz";
     type ErrorCallBack = (error: any, result: any) => any;
 
+    class UploadStream extends Transform {
+    }
+
     export namespace v2 {
 
         /****************************** Global Utils *************************************/
@@ -819,9 +825,9 @@ declare module 'cloudinary' {
 
             function unsigned_upload(file: string, upload_preset: string, callback?: ErrorCallBack): Promise<any>;
 
-            function unsigned_upload_stream(upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
+            function unsigned_upload_stream(upload_preset: string, options?: UploadApiOptions, callback?: ErrorCallBack): UploadStream;
 
-            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack): Promise<any>;
+            function unsigned_upload_stream(upload_preset: string, callback?: ErrorCallBack): UploadStream;
 
             function upload(file: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
@@ -831,15 +837,15 @@ declare module 'cloudinary' {
 
             function upload_chunked(path: string, callback?: ErrorCallBack): Promise<any>;
 
-            function upload_chunked_stream(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
+            function upload_chunked_stream(options?: UploadApiOptions, callback?: ErrorCallBack): UploadStream;
 
             function upload_large(path: string, options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 
             function upload_large(path: string, callback?: ErrorCallBack): Promise<any>;
 
-            function upload_stream(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
+            function upload_stream(options?: UploadApiOptions, callback?: ErrorCallBack): UploadStream;
 
-            function upload_stream(callback?: ErrorCallBack): Promise<any>;
+            function upload_stream(callback?: ErrorCallBack): UploadStream;
 
             function upload_tag_params(options?: UploadApiOptions, callback?: ErrorCallBack): Promise<any>;
 


### PR DESCRIPTION
All stream upload methods return stream itself, not promise.
This PR fixes typings for them