### PR TITLE
Fixed a bug in the tests that would incorrectly create directories in the fs

### DIFF
--- a/lib-es5/cache/FileKeyValueStorage.js
+++ b/lib-es5/cache/FileKeyValueStorage.js
@@ -64,10 +64,7 @@ var FileKeyValueStorage = function () {
   }, {
     key: 'deleteBaseFolder',
     value: function deleteBaseFolder() {
-      console.log('Deleting');
-      console.log(this.baseFolder);
-      var res = rimraf(this.baseFolder);
-      console.log(res);
+      rimraf(this.baseFolder);
     }
   }, {
     key: 'getFilename',

--- a/lib-es5/cache/FileKeyValueStorage.js
+++ b/lib-es5/cache/FileKeyValueStorage.js
@@ -21,13 +21,13 @@ var FileKeyValueStorage = function () {
   _createClass(FileKeyValueStorage, [{
     key: 'init',
     value: function init(baseFolder) {
-      var _this = this;
-
       if (baseFolder) {
-        fs.access(baseFolder, function (err, result) {
-          if (err) throw err;
-          _this.baseFolder = baseFolder;
-        });
+        try {
+          fs.accessSync(baseFolder);
+          this.baseFolder = baseFolder;
+        } catch (err) {
+          throw err;
+        }
       } else {
         if (!fs.existsSync('test_cache')) {
           fs.mkdirSync('test_cache');
@@ -54,17 +54,20 @@ var FileKeyValueStorage = function () {
   }, {
     key: 'clear',
     value: function clear() {
-      var _this2 = this;
+      var _this = this;
 
       var files = fs.readdirSync(this.baseFolder);
       files.forEach(function (file) {
-        return fs.unlinkSync(path.join(_this2.baseFolder, file));
+        return fs.unlinkSync(path.join(_this.baseFolder, file));
       });
     }
   }, {
     key: 'deleteBaseFolder',
     value: function deleteBaseFolder() {
-      rimraf(this.baseFolder);
+      console.log('Deleting');
+      console.log(this.baseFolder);
+      var res = rimraf(this.baseFolder);
+      console.log(res);
     }
   }, {
     key: 'getFilename',

--- a/lib/cache/FileKeyValueStorage.js
+++ b/lib/cache/FileKeyValueStorage.js
@@ -9,10 +9,12 @@ class FileKeyValueStorage {
 
   init(baseFolder) {
     if (baseFolder) {
-      fs.access(baseFolder, (err, result) => {
-        if (err) throw err;
+      try {
+        fs.accessSync(baseFolder);
         this.baseFolder = baseFolder;
-      });
+      } catch (err) {
+        throw err;
+      }
     } else {
       if (!fs.existsSync('test_cache')) {
         fs.mkdirSync('test_cache');

--- a/test/cache/FileKeyValueCache_spec.js
+++ b/test/cache/FileKeyValueCache_spec.js
@@ -12,7 +12,7 @@ const VALUE2 = "test_value_2";
 
 describe("FileKeyValueStorage", () => {
   var storage;
-  var basefolder;
+  var baseFolder;
 
   function getTestValue(key) {
     let storedValue = fs.readFileSync(storage.getFilename(key));
@@ -22,13 +22,13 @@ describe("FileKeyValueStorage", () => {
   before(() => {
     const cwd = process.cwd();
     const { sep } = path;
-    basefolder = fs.mkdtempSync(`${cwd}${sep}`);
-    storage = new FileKeyValueStorage(basefolder);
+    baseFolder = fs.mkdtempSync(`${cwd}${sep}`);
+    storage = new FileKeyValueStorage({ baseFolder });
   });
 
   after(() => {
     storage.deleteBaseFolder();
-    expect(fs.accessSync(basefolder)).to.be(undefined);
+    expect(fs.existsSync(baseFolder)).to.be(false);
   });
 
   it("should set a value in a file", () => {


### PR DESCRIPTION
- The fs.access method was used in correctly, (this method is async, and cannot set values when ran in a sync manner.

We should either use a promise or the sync variant.

- Fixed an error in the test file which passed a string instead of an object to the `FileKeyValueStorage` constructor