### PR TITLE
Added automation to delete the es5-lib dir on every compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsdom-global": "2.1.1",
     "mocha": "^5.0.0",
     "nyc": "^13.3.0",
+    "rimraf": "^3.0.0",
     "sinon": "^6.1.4",
     "webpack-cli": "^3.2.1"
   },

--- a/tools/scripts/compile.sh
+++ b/tools/scripts/compile.sh
@@ -1,1 +1,2 @@
-babel lib --out-dir lib-es5 --delete-dir-on-start --verbose
+rimraf ./lib-es5
+babel lib --out-dir lib-es5 --verbose

--- a/tools/scripts/test.sh
+++ b/tools/scripts/test.sh
@@ -1,4 +1,4 @@
-set -e node_v=$(node --version)z
+set -e node_v=$(node --version)
 if [[ "${node_v%%.*z}" == 'v4' ]]
 then
   npm run test-es5


### PR DESCRIPTION
It seems that  --delete-dir-on-start  is not supported on our version of babel (couldn't find it on the docs of babel 6.26)

As such, the es5-lib is never deleted.
This PR adds rimraf as a cross platform deleting command and removes the es5-lib every time we compile.

also fixed a typo in test.sh