### PR TITLE
Change coverage output : from text to HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 test_cache/
 .nyc_output
 docs
+coverage

--- a/tools/scripts/test.es6.sh
+++ b/tools/scripts/test.es6.sh
@@ -11,7 +11,7 @@ done
 
 if [ "$COLLECT_COVERAGE" -eq "1" ]; then
   echo 'Running code coverage test on ES6 code'
-  nyc --reporter=text mocha --ui bdd -R spec --recursive test/
+  nyc --reporter=html mocha --ui bdd -R spec --recursive test/
   exit;
 else
   echo 'Running tests on ES6 Code'


### PR DESCRIPTION
This change will create a ./coverage directory with all coverage details in a static website.
When opening the file, you could navigate and see which lines of code are not covered.

<img width="861" alt="Screen Shot 2020-02-12 at 9 55 12" src="https://user-images.githubusercontent.com/59408474/74314290-dc454780-4d7d-11ea-80ca-c22d06278c0c.png">
