### PR TITLE
Support multiple resource_types in ZIP generation

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -661,7 +661,6 @@ function patchFetchFormat() {
 function url(public_id) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-
   var signature = void 0,
       source_to_sign = void 0;
   utils.patchFetchFormat(options);
@@ -1039,6 +1038,8 @@ function zip_download_url(tag) {
  * @param {string|Array} [options.tags] list of tags to include in the archive
  * @param {string|Array<string>} [options.public_ids] list of public_ids to include in the archive
  * @param {string|Array<string>} [options.prefixes]  list of prefixes of public IDs (e.g., folders).
+ * @param {string|Array<string>} [options.fully_qualified_public_ids] list of fully qualified public_ids to include
+ *   in the archive.
  * @param {string|Array<string>} [options.transformations]  list of transformations.
  *   The derived images of the given transformations are included in the archive. Using the string representation of
  *   multiple chained transformations as we use for the 'eager' upload parameter.
@@ -1260,6 +1261,7 @@ function archive_params() {
     mode: options.mode,
     notification_url: options.notification_url,
     prefixes: options.prefixes && toArray(options.prefixes),
+    fully_qualified_public_ids: options.fully_qualified_public_ids && toArray(options.fully_qualified_public_ids),
     public_ids: options.public_ids && toArray(options.public_ids),
     skip_transformation_name: exports.as_safe_bool(options.skip_transformation_name),
     tags: options.tags && toArray(options.tags),

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -599,7 +599,6 @@ function patchFetchFormat(options = {}) {
 }
 
 function url(public_id, options = {}) {
-
   let signature, source_to_sign;
   utils.patchFetchFormat(options);
   let type = consumeOption(options, "type", null);
@@ -953,6 +952,8 @@ function zip_download_url(tag, options = {}) {
  * @param {string|Array} [options.tags] list of tags to include in the archive
  * @param {string|Array<string>} [options.public_ids] list of public_ids to include in the archive
  * @param {string|Array<string>} [options.prefixes]  list of prefixes of public IDs (e.g., folders).
+ * @param {string|Array<string>} [options.fully_qualified_public_ids] list of fully qualified public_ids to include
+ *   in the archive.
  * @param {string|Array<string>} [options.transformations]  list of transformations.
  *   The derived images of the given transformations are included in the archive. Using the string representation of
  *   multiple chained transformations as we use for the 'eager' upload parameter.
@@ -1157,6 +1158,7 @@ function archive_params(options = {}) {
     mode: options.mode,
     notification_url: options.notification_url,
     prefixes: options.prefixes && toArray(options.prefixes),
+    fully_qualified_public_ids: options.fully_qualified_public_ids && toArray(options.fully_qualified_public_ids),
     public_ids: options.public_ids && toArray(options.public_ids),
     skip_transformation_name: exports.as_safe_bool(options.skip_transformation_name),
     tags: options.tags && toArray(options.tags),

--- a/test/archivespec.js
+++ b/test/archivespec.js
@@ -16,12 +16,15 @@ const helper = require("./spechelper");
 const { utils, api, uploader } = cloudinary.v2;
 const TEST_TAG = helper.TEST_TAG;
 const IMAGE_URL = helper.IMAGE_URL;
+const VIDEO_URL = helper.VIDEO_URL;
 const sharedExamples = helper.sharedExamples;
 const includeContext = helper.includeContext;
 const ARCHIVE_TAG = TEST_TAG + "_archive";
 const PUBLIC_ID1 = ARCHIVE_TAG + "_1";
 const PUBLIC_ID2 = ARCHIVE_TAG + "_2";
 const PUBLIC_ID_RAW = ARCHIVE_TAG + "_3";
+const FULLY_QUALIFIED_IMAGE = "image/upload/sample";
+const FULLY_QUALIFIED_VIDEO = "video/upload/dog";
 
 sharedExamples('archive', function () {
   before("Verify Configuration", function () {
@@ -54,6 +57,12 @@ sharedExamples('archive', function () {
         {
           public_id: PUBLIC_ID_RAW,
           resource_type: "raw",
+          tags: helper.UPLOAD_TAGS.concat([ARCHIVE_TAG]),
+        }),
+      uploader.upload(VIDEO_URL,
+        {
+          public_id: "dog",
+          resource_type: "video",
           tags: helper.UPLOAD_TAGS.concat([ARCHIVE_TAG]),
         }),
     ]);
@@ -150,6 +159,14 @@ describe("archive", function () {
           sinon.assert.calledWith(write, sinon.match(helper.uploadParamMatcher("public_ids[]", "non-existing-resource")));
           sinon.assert.calledWith(write, sinon.match(helper.uploadParamMatcher("allow_missing", 1)));
           sinon.assert.calledWith(write, sinon.match(helper.uploadParamMatcher("target_format", "zip")));
+        });
+      });
+      it('should create archive with "zip" format and include multiple resource types', function () {
+        return uploader.create_zip({
+          fully_qualified_public_ids: [FULLY_QUALIFIED_IMAGE, FULLY_QUALIFIED_VIDEO],
+          resource_type: "auto",
+        }).then((result) => {
+          expect(result.file_count).to.eql(2);
         });
       });
     });

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -36,6 +36,7 @@ exports.LARGE_VIDEO = "test/resources/CloudBookStudy-HD.mp4";
 exports.EMPTY_IMAGE = "test/resources/empty.gif";
 exports.RAW_FILE = "test/resources/docx.docx";
 exports.ICON_FILE = "test/resources/favicon.ico";
+exports.VIDEO_URL = "http://res.cloudinary.com/demo/video/upload/dog.mp4";
 exports.IMAGE_URL = "http://res.cloudinary.com/demo/image/upload/sample";
 
 exports.test_cloudinary_url = function (public_id, options, expected_url, expected_options) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -400,6 +400,7 @@ declare module 'cloudinary' {
         notification_url?: string;
         prefixes?: string;
         public_ids?: string[] | string;
+        fully_qualified_public_ids?: string[] | string;
         skip_transformation_name?: boolean;
         tags?: string | string[];
         target_format?: TargetArchiveFormat;


### PR DESCRIPTION
As discussed, the current Node.js implementation of `create_archive()` does not validate any input and does not throw any errors (except ones thrown by the API). The .net implementation does include validation and throws some errors.

This addition to `create_archive()` will not add validation to comply with the rest of this SKDs style.