### PR TITLE
Refactor the order of the assertions in account_spec

### DIFF
--- a/test/provisioning/account_spec.js
+++ b/test/provisioning/account_spec.js
@@ -52,13 +52,11 @@ describe('account API - Provisioning', function () {
 
   after('Destroy the sub account and user that was created', async () => {
     let delRes = await cloudinary.provisioning.account.delete_sub_account(CLOUD_ID);
-    expect(delRes.message).to.eql('ok');
-
-
     let delUserRes = await cloudinary.provisioning.account.delete_user(USER_ID);
-    expect(delUserRes.message).to.eql('ok');
-
     let delGroupRes = await cloudinary.provisioning.account.delete_user_group(GROUP_ID);
+
+    expect(delRes.message).to.eql('ok');
+    expect(delUserRes.message).to.eql('ok');
     expect(delGroupRes.ok).to.eql(true); // notice the different response structure
   });
 


### PR DESCRIPTION
The reasoning for this is that if the first expect fails it will not send the other requests,
which will pollute our account