### PR TITLE
Refactor in a wait period for eager uploads

### DIFF
--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -51,6 +51,14 @@ const LABEL_INT_1 = 'metadata_label_1_' + TEST_ID;
 const LABEL_INT_2 = 'metadata_label_2_' + TEST_ID;
 const LABEL_INT_3 = 'metadata_label_3_' + TEST_ID;
 
+function wait(ms = 0) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
 sharedExamples("a list with a cursor", function (testFunc, ...args) {
   specify(":max_results", function () {
     return helper.mockPromise(function (xhr, writeSpy, requestSpy) {
@@ -365,7 +373,7 @@ describe("api", function () {
           tags: UPLOAD_TAGS,
           eager: [EXPLICIT_TRANSFORMATION, EXPLICIT_TRANSFORMATION2],
         }),
-      ]).then(() => cloudinary.v2.api.delete_derived_by_transformation(
+      ]).then(wait(2000)).then(() => cloudinary.v2.api.delete_derived_by_transformation(
         [PUBLIC_ID_1, PUBLIC_ID_3], [EXPLICIT_TRANSFORMATION, EXPLICIT_TRANSFORMATION2]
       )).then(
         () => cloudinary.v2.api.resource(PUBLIC_ID_1)

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -673,17 +673,17 @@ describe("api", function () {
       });
     });
     it("should allow creating upload_presets", function () {
-      return helper.mockPromise(async function (xhr, write) {
-        let preset = await cloudinary.v2.api.create_upload_preset({
+      return helper.mockPromise(function (xhr, write) {
+        cloudinary.v2.api.create_upload_preset({
           folder: "upload_folder",
           unsigned: true,
-          tags: UPLOAD_TAGS,
+          tags: ['TESTRAYA', ...UPLOAD_TAGS],
           live: true
-        });
-
-        await cloudinary.v2.api.delete_upload_preset(preset.name).catch((err) => {
-          console.log(err);
-          // we don't fail the test if the delete fails
+        }).then((preset) => {
+          cloudinary.v2.api.delete_upload_preset(preset.name).catch((err) => {
+            console.log(err);
+            // we don't fail the test if the delete fails
+          });
         });
 
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('unsigned', true, "unsigned=true")));

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -373,7 +373,7 @@ describe("api", function () {
           tags: UPLOAD_TAGS,
           eager: [EXPLICIT_TRANSFORMATION, EXPLICIT_TRANSFORMATION2],
         }),
-      ]).then(wait(2000)).then(() => cloudinary.v2.api.delete_derived_by_transformation(
+      ]).then(wait(4000)).then(() => cloudinary.v2.api.delete_derived_by_transformation(
         [PUBLIC_ID_1, PUBLIC_ID_3], [EXPLICIT_TRANSFORMATION, EXPLICIT_TRANSFORMATION2]
       )).then(
         () => cloudinary.v2.api.resource(PUBLIC_ID_1)
@@ -677,7 +677,7 @@ describe("api", function () {
         cloudinary.v2.api.create_upload_preset({
           folder: "upload_folder",
           unsigned: true,
-          tags: ['TESTRAYA', ...UPLOAD_TAGS],
+          tags: UPLOAD_TAGS,
           live: true
         }).then((preset) => {
           cloudinary.v2.api.delete_upload_preset(preset.name).catch((err) => {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -338,7 +338,7 @@ describe("api", function () {
             crop: "scale",
           },
         ],
-      }).then(
+      }).then(wait(2000)).then(
         ({ public_id }) => cloudinary.v2.api.resource(public_id)
           .then(resource => [public_id, resource])
       ).then(([public_id, resource]) => {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -673,13 +673,19 @@ describe("api", function () {
       });
     });
     it("should allow creating upload_presets", function () {
-      return helper.mockPromise(function (xhr, write) {
-        cloudinary.v2.api.create_upload_preset({
+      return helper.mockPromise(async function (xhr, write) {
+        let preset = await cloudinary.v2.api.create_upload_preset({
           folder: "upload_folder",
           unsigned: true,
           tags: UPLOAD_TAGS,
           live: true
         });
+
+        await cloudinary.v2.api.delete_upload_preset(preset.name).catch((err) => {
+          console.log(err);
+          // we don't fail the test if the delete fails
+        });
+
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('unsigned', true, "unsigned=true")));
         sinon.assert.calledWith(write, sinon.match(helper.apiParamMatcher('live', true, "live=true")));
       });


### PR DESCRIPTION
The current tests are failing randomally, as the even though we've receieved a response
from the server, the back-end operation is not yet done.
any request to delete the derived asset when it doesn't exist will fail, thus fail the test.

This fix adds a small timeout to the request, we might want to consider a more long-term solution.

However, this usecase is not really common (upload and immediately delete)