### PR TITLE
Add `rate_limits` back to responses sent from Admin API

### DIFF
--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -77,6 +77,10 @@ function execute_request(method, params, auth, api_url, callback) {
 
         if (result.error) {
           result.error.http_code = res.statusCode;
+        } else {
+          result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
+          result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
+          result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
         }
 
         if (result.error) {

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -70,6 +70,10 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
 
         if (result.error) {
           result.error.http_code = res.statusCode;
+        } else {
+          result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
+          result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
+          result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
         }
 
         if (result.error) {

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -475,6 +475,17 @@ describe("api", function () {
       }).then(result => expect(result.tags).to.be.empty());
     });
   });
+  describe("headers", function () {
+    it("should include rate limits", function () {
+      this.timeout(helper.TIMEOUT_MEDIUM);
+      return cloudinary.v2.api.resources().then(function (result) {
+        expect(result.rate_limit_allowed).to.be.a("number");
+        expect(result.rate_limit_reset_at).to.be.an("object");
+        expect(result.rate_limit_reset_at).to.have.property("getDate");
+        expect(result.rate_limit_remaining).to.be.a("number");
+      });
+    });
+  });
   describe("transformations", function () {
     var transformationName;
     itBehavesLike("a list with a cursor", cloudinary.v2.api.transformation, EXPLICIT_TRANSFORMATION_NAME);

--- a/test/streaming_profiles_spec.js
+++ b/test/streaming_profiles_spec.js
@@ -51,7 +51,7 @@ describe('Cloudinary::Api', function () {
         expect(result).not.to.be(void 0);
       });
     });
-    it('should create a streaming profile with an array of transformation', function () {
+    it('should create a streaming profile with an array of transformations', function () {
       return api.create_streaming_profile(test_id_1 + 'a', {
         representations: [
           {


### PR DESCRIPTION
Restores the three properties that were removed from Admin API responses in SDK v1.20.0:
* `rate_limit_allowed`
* `rate_limit_reset_at`
* `rate_limit_remaining`
