### PR TITLE
Fix normalize_expression when variable is named like a keyword (e.g., "$width")

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -137,12 +137,20 @@ function normalize_expression(expression) {
   if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
     return expression;
   }
+
   var operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-  var pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(PREDEFINED_VARS).join("|") + "))";
-  var replaceRE = new RegExp(pattern, "g");
-  expression = expression.replace(replaceRE, function (match) {
-    return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];
+  var operatorsPattern = "((" + operators + ")(?=[ _]))";
+  var operatorsReplaceRE = new RegExp(operatorsPattern, "g");
+  expression = expression.replace(operatorsReplaceRE, function (match) {
+    return CONDITIONAL_OPERATORS[match];
   });
+
+  var predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  var predefinedVarsReplaceRE = new RegExp(predefinedVarsPattern, "g");
+  expression = expression.replace(predefinedVarsReplaceRE, function (match, p1, offset) {
+    return expression[offset - 1] === '$' ? match : PREDEFINED_VARS[match];
+  });
+
   return expression.replace(/[ _]+/g, '_');
 }
 

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -138,7 +138,7 @@ function normalize_expression(expression) {
     return expression;
   }
   var operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-  var pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  var pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(PREDEFINED_VARS).join("|") + "))";
   var replaceRE = new RegExp(pattern, "g");
   expression = expression.replace(replaceRE, function (match) {
     return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -127,12 +127,16 @@ function normalize_expression(expression) {
   if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
     return expression;
   }
+
   const operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-  const pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(PREDEFINED_VARS).join("|") + "))";
-  const replaceRE = new RegExp(pattern, "g");
-  expression = expression.replace(replaceRE, function (match) {
-    return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];
-  });
+  const operatorsPattern = "((" + operators + ")(?=[ _]))";
+  const operatorsReplaceRE = new RegExp(operatorsPattern, "g");
+  expression = expression.replace(operatorsReplaceRE, match => CONDITIONAL_OPERATORS[match]);
+
+  const predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  const predefinedVarsReplaceRE = new RegExp(predefinedVarsPattern, "g");
+  expression = expression.replace(predefinedVarsReplaceRE, (match, p1, offset) => (expression[offset - 1] === '$' ? match : PREDEFINED_VARS[match]));
+
   return expression.replace(/[ _]+/g, '_');
 }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -128,7 +128,7 @@ function normalize_expression(expression) {
     return expression;
   }
   const operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-  const pattern = "((" + operators + ")(?=[ _])|" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  const pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(PREDEFINED_VARS).join("|") + "))";
   const replaceRE = new RegExp(pattern, "g");
   expression = expression.replace(replaceRE, function (match) {
     return CONDITIONAL_OPERATORS[match] || PREDEFINED_VARS[match];

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1052,7 +1052,7 @@ describe("utils", function () {
         t = cloudinary.utils.generate_transformation_string(options);
         expect(t).to.eql("$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end");
       });
-      it("should not change variable names that are named after keyword", function () {
+      it("should not change variable names even if they look like keywords", function () {
         var options, t;
         options = {
           transformation: [

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1052,6 +1052,21 @@ describe("utils", function () {
         t = cloudinary.utils.generate_transformation_string(options);
         expect(t).to.eql("$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end");
       });
+      it("should not change variable names that are named after keyword", function () {
+        var options, t;
+        options = {
+          transformation: [
+            {
+              $width: 10,
+            },
+            {
+              width: "$width + 10 + width",
+            },
+          ],
+        };
+        t = cloudinary.utils.generate_transformation_string(options);
+        expect(t).to.eql("$width_10/w_$width_add_10_add_w");
+      });
       it("should support text values", function () {
         test_cloudinary_url("sample", {
           effect: "$efname:100",


### PR DESCRIPTION
`normalize_expression()` will no longer transform predefined variables into their shortened form if they are preceded by an ampersand (meaning they are variables).

For example: `$width` will not be transformed into `$w`.

Please note that the regular expression code that was used in other SDKs could not be used here in order to maintain compatibility with Node.js 6.x.x and older. These versions of Node.js do not support lookbehind in regular expressions.

328a33d is the initial implementation which uses the lookbehind regexp code. You can see how this fails in Travis running  Node.js 6 [here](https://travis-ci.org/github/cloudinary/cloudinary_npm/jobs/671317830#L1959).

ae8cfaf is a fix which no longer uses lookbehind and works in Node.js 6 as can be seen [here](https://travis-ci.org/github/cloudinary/cloudinary_npm/jobs/673602270#L797).