### PR TITLE
Refactor the location of all custom assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     // "consistent-return": "off",
     // "dot-notation": "off",
     "func-names": "off",
-    // "global-require": "off",
+    "global-require": "off",
     // "guard-for-in": "off",
     // "import/newline-after-import": "off",
     "import/no-dynamic-require": "off",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.2",
     "expect.js": "0.3.x",
+    "glob": "^7.1.6",
     "jsdoc": "^3.5.5",
     "jsdom": "^9.12.0",
     "jsdom-global": "2.1.1",

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -1,17 +1,17 @@
 const expect = require('expect.js');
 const isFunction = require('lodash/isFunction');
-const cloneDeep = require('lodash/cloneDeep');
 const querystring = require('querystring');
 const sinon = require('sinon');
 const ClientRequest = require('_http_client').ClientRequest;
 const Q = require('q');
 const http = require('http');
 const https = require('https');
+// Load all our custom assertions
+require('./testUtils/testBootstrap');
 
 const cloudinary = require("../cloudinary");
 
 const { utils, config, Cache } = cloudinary;
-const { isEmpty, includes } = utils;
 
 const libPath = Number(process.versions.node.split('.')[0]) < 8 ? 'lib-es5' : 'lib';
 const FileKeyValueStorage = require(`../${libPath}/cache/FileKeyValueStorage`);
@@ -64,153 +64,6 @@ exports.test_cloudinary_url = function(public_id, options, expected_url, expecte
   return url;
 };
 
-expect.Assertion.prototype.produceUrl = function (url) {
-  var actual, actualOptions, options, public_id;
-  [public_id, options] = this.obj;
-  actualOptions = cloneDeep(options);
-  actual = utils.url(public_id, actualOptions);
-  this.assert(actual.match(url), function () {
-    return `expected '${public_id}' and ${JSON.stringify(options)} to produce '${url}' but got '${actual}'`;
-  }, function () {
-    return `expected '${public_id}' and ${JSON.stringify(options)} not to produce '${url}' but got '${actual}'`;
-  });
-  return this;
-};
-
-expect.Assertion.prototype.emptyOptions = function () {
-  var actual, options, public_id;
-  [public_id, options] = this.obj;
-  actual = cloneDeep(options);
-  utils.url(public_id, actual);
-  this.assert(isEmpty(actual), function () {
-    return `expected '${public_id}' and ${JSON.stringify(options)} to produce empty options but got ${JSON.stringify(actual)}`;
-  }, function () {
-    return `expected '${public_id}' and ${JSON.stringify(options)} not to produce empty options`;
-  });
-  return this;
-};
-
-expect.Assertion.prototype.beServedByCloudinary = function (done) {
-  var actual, actualOptions, callHttp, options, public_id;
-  [public_id, options] = this.obj;
-  actualOptions = cloneDeep(options);
-  actual = utils.url(public_id, actualOptions);
-  if (actual.startsWith("https")) {
-    callHttp = https;
-  } else {
-    callHttp = http;
-  }
-  callHttp.get(actual, (res) => {
-    this.assert(res.statusCode === 200, function () {
-      return `Expected to get ${actual} but server responded with "${res.statusCode}: ${res.headers['x-cld-error']}"`;
-    }, function () {
-      return `Expeted not to get ${actual}.`;
-    });
-    return done();
-  });
-  return this;
-};
-
-/**
- * Asserts that a given object is a datasource.
- *
- * @returns {expect.Assertion}
- */
-expect.Assertion.prototype.beADatasource = function () {
-  let datasource;
-  datasource = this.obj;
-  this.assert('values' in datasource, function () {
-    return `expected datasource to contain mandatory field: 'values'`;
-  }, function () {
-    return `expected datasource not to contain a 'values' field`;
-  });
-  if (!isEmpty(datasource.values)) {
-    datasource.values.forEach((value) => {
-      this.assert(typeof value.value === 'string', function () {
-        return `expected datasource to contain item with mandatory field 'value' type string`;
-      }, function () {
-        return `expected datasource not to contain item with mandatory field 'value' type string`;
-      });
-      this.assert(typeof value.external_id === 'string', function () {
-        return `expected datasource field to contain item with mandatory field: 'value' type string`;
-      }, function () {
-        return `expected datasource not to contain item with mandatory field 'external_id' type string`;
-      });
-      if (!isEmpty(value.state)) {
-        const states = ['active', 'inactive'];
-        this.assert(includes(states, value.state), function () {
-          return `expected datasource field state to be one of ${states.join(', ')}. Unknown state ${value.state} received`;
-        }, function () {
-          return `expected datasource field state not to be of a certain state`;
-        });
-      }
-    });
-  }
-  return this;
-};
-
-/**
- * Asserts that a given object is a metadata field.
- * Optionally tests the values in the metadata field for equality
- *
- * @param {string} type The type of metadata field we expect
- * @returns {expect.Assertion}
- */
-expect.Assertion.prototype.beAMetadataField = function (type = '') {
-  let metadataField, expectedValues;
-  if (Array.isArray(this.obj)) {
-    [metadataField, expectedValues] = this.obj;
-  } else {
-    metadataField = this.obj;
-  }
-  // Check that all mandatory keys exist
-  const mandatoryKeys = ['type', 'external_id', 'label', 'mandatory', 'default_value', 'validation'];
-  mandatoryKeys.forEach((key) => {
-    this.assert(key in metadataField, function () {
-      return `expected metadata field to contain mandatory field: ${key}`;
-    }, function () {
-      return `expected metadata field not to contain a ${key} field`;
-    });
-  });
-
-  // If type is enum or set test it
-  if (includes(['enum', 'set'], metadataField.type)) {
-    this.assert('datasource' in metadataField, function () {
-      return `expected metadata field of type ${metadataField.type} to contain a datasource field`;
-    }, function () {
-      return `expected metadata field of type ${metadataField.type} not to contain a datasource field`;
-    });
-    expect(metadataField.datasource).to.beADatasource();
-  }
-
-  // Make sure type is acceptable
-  if (type) {
-    this.assert(type === metadataField.type, function () {
-      return `expected metadata field type to equal ${type}`;
-    }, function () {
-      return `expected metadata field type ${metadataField.type} not to equal ${type}`;
-    });
-  } else {
-    const acceptableTypes = ['string', 'integer', 'date', 'enum', 'set'];
-    this.assert(includes(acceptableTypes, metadataField.type), function () {
-      return `expected metadata field type to be one of ${acceptableTypes.join(', ')}. Unknown field type ${metadataField.type} received`;
-    }, function () {
-      return `expected metadata field not to be of a certain type`;
-    });
-  }
-  // Verify object values
-  if (expectedValues) {
-    Object.entries(expectedValues).forEach(([key, value]) => {
-      this.assert(metadataField[key] === value, function () {
-        return `expected metadata field's ${key} to equal ${value} but got ${metadataField[key]} instead`;
-      }, function () {
-        return `expected metadata field's ${key} not to equal ${value}`;
-      });
-    });
-  }
-
-  return this;
-};
 
 const allExamples = {};
 

--- a/test/testUtils/assertions/beADatasource.js
+++ b/test/testUtils/assertions/beADatasource.js
@@ -1,0 +1,54 @@
+const expect = require('expect.js');
+const isEmpty = require("lodash/isEmpty");
+const includes = require('lodash/includes');
+
+
+const ERRORS = {
+  MUST_CONTAIN_VALUES: `expected datasource to contain mandatory field: 'values'`,
+  MUST_NOT_CONTAIN_VALUES: `expected datasource not to contain a 'values' field`,
+  INNER_VALUE_MUST_BE_STRING: `expected datasource to contain item with mandatory field 'value' type string`,
+  INNER_VALUE_MUST_NOT_BE_STRING: `expected datasource not to contain item with mandatory field 'value' type string`,
+  EXTERNAL_ID_MUST_BE_STRING: `expected datasource field to contain item with mandatory field: 'value' type string`,
+  EXTERNAL_ID_MUST_NOT_BE_STRING: `expected datasource not to contain item with mandatory field 'external_id' type string`,
+  STATE_MUST_BE_ONE_OF: (states, state) => `expected datasource field state to be one of ${states}. Unknown state ${state} received`,
+  STATE_MUST_NOT_BE_ONE_OF: states => `expected datasource field state not to be of ${states}`,
+};
+
+/**
+ * Asserts that a given object is a datasource.
+ *
+ * @returns {expect.Assertion}
+ */
+expect.Assertion.prototype.beADatasource = function () {
+  let datasource;
+  datasource = this.obj;
+  this.assert('values' in datasource, function () {
+    return ERRORS.MUST_CONTAIN_VALUES;
+  }, function () {
+    return ERRORS.MUST_NOT_CONTAIN_VALUES;
+  });
+
+  if (!isEmpty(datasource.values)) {
+    datasource.values.forEach((value) => {
+      this.assert(typeof value.value === 'string', function () {
+        return ERRORS.INNER_VALUE_MUST_BE_STRING;
+      }, function () {
+        return ERRORS.INNER_VALUE_MUST_NOT_BE_STRING;
+      });
+      this.assert(typeof value.external_id === 'string', function () {
+        return ERRORS.EXTERNAL_ID_MUST_BE_STRING;
+      }, function () {
+        return ERRORS.EXTERNAL_ID_MUST_NOT_BE_STRING;
+      });
+      if (!isEmpty(value.state)) {
+        const states = ['active', 'inactive'];
+        this.assert(includes(states, value.state), function () {
+          return ERRORS.STATE_MUST_BE_ONE_OF(states.join(', '), value.state);
+        }, function () {
+          return ERRORS.STATE_MUST_NOT_BE_ONE_OF(states.join(', '));
+        });
+      }
+    });
+  }
+  return this;
+};

--- a/test/testUtils/assertions/beAMetadataField.js
+++ b/test/testUtils/assertions/beAMetadataField.js
@@ -1,0 +1,65 @@
+const expect = require('expect.js');
+const includes = require('lodash/includes');
+
+/**
+ * Asserts that a given object is a metadata field.
+ * Optionally tests the values in the metadata field for equality
+ *
+ * @param {string} type The type of metadata field we expect
+ * @returns {expect.Assertion}
+ */
+expect.Assertion.prototype.beAMetadataField = function (type = '') {
+  let metadataField, expectedValues;
+  if (Array.isArray(this.obj)) {
+    [metadataField, expectedValues] = this.obj;
+  } else {
+    metadataField = this.obj;
+  }
+  // Check that all mandatory keys exist
+  const mandatoryKeys = ['type', 'external_id', 'label', 'mandatory', 'default_value', 'validation'];
+  mandatoryKeys.forEach((key) => {
+    this.assert(key in metadataField, function () {
+      return `expected metadata field to contain mandatory field: ${key}`;
+    }, function () {
+      return `expected metadata field not to contain a ${key} field`;
+    });
+  });
+
+  // If type is enum or set test it
+  if (includes(['enum', 'set'], metadataField.type)) {
+    this.assert('datasource' in metadataField, function () {
+      return `expected metadata field of type ${metadataField.type} to contain a datasource field`;
+    }, function () {
+      return `expected metadata field of type ${metadataField.type} not to contain a datasource field`;
+    });
+    expect(metadataField.datasource).to.beADatasource();
+  }
+
+  // Make sure type is acceptable
+  if (type) {
+    this.assert(type === metadataField.type, function () {
+      return `expected metadata field type to equal ${type}`;
+    }, function () {
+      return `expected metadata field type ${metadataField.type} not to equal ${type}`;
+    });
+  } else {
+    const acceptableTypes = ['string', 'integer', 'date', 'enum', 'set'];
+    this.assert(includes(acceptableTypes, metadataField.type), function () {
+      return `expected metadata field type to be one of ${acceptableTypes.join(', ')}. Unknown field type ${metadataField.type} received`;
+    }, function () {
+      return `expected metadata field not to be of a certain type`;
+    });
+  }
+  // Verify object values
+  if (expectedValues) {
+    Object.entries(expectedValues).forEach(([key, value]) => {
+      this.assert(metadataField[key] === value, function () {
+        return `expected metadata field's ${key} to equal ${value} but got ${metadataField[key]} instead`;
+      }, function () {
+        return `expected metadata field's ${key} not to equal ${value}`;
+      });
+    });
+  }
+
+  return this;
+};

--- a/test/testUtils/assertions/beServedByCloudinary.js
+++ b/test/testUtils/assertions/beServedByCloudinary.js
@@ -2,14 +2,14 @@ const expect = require('expect.js');
 const cloneDeep = require('lodash/cloneDeep');
 const http = require('http');
 const https = require('https');
-const utils = require('../../../cloudinary');
+const cloudinary = require('../../../cloudinary');
 
 
 expect.Assertion.prototype.beServedByCloudinary = function (done) {
   var actual, actualOptions, callHttp, options, public_id;
   [public_id, options] = this.obj;
   actualOptions = cloneDeep(options);
-  actual = utils.url(public_id, actualOptions);
+  actual = cloudinary.url(public_id, actualOptions);
   if (actual.startsWith("https")) {
     callHttp = https;
   } else {

--- a/test/testUtils/assertions/beServedByCloudinary.js
+++ b/test/testUtils/assertions/beServedByCloudinary.js
@@ -1,0 +1,27 @@
+const expect = require('expect.js');
+const cloneDeep = require('lodash/cloneDeep');
+const http = require('http');
+const https = require('https');
+const utils = require('../../../cloudinary');
+
+
+expect.Assertion.prototype.beServedByCloudinary = function (done) {
+  var actual, actualOptions, callHttp, options, public_id;
+  [public_id, options] = this.obj;
+  actualOptions = cloneDeep(options);
+  actual = utils.url(public_id, actualOptions);
+  if (actual.startsWith("https")) {
+    callHttp = https;
+  } else {
+    callHttp = http;
+  }
+  callHttp.get(actual, (res) => {
+    this.assert(res.statusCode === 200, function () {
+      return `Expected to get ${actual} but server responded with "${res.statusCode}: ${res.headers['x-cld-error']}"`;
+    }, function () {
+      return `Expeted not to get ${actual}.`;
+    });
+    return done();
+  });
+  return this;
+};

--- a/test/testUtils/assertions/emptyOptions.js
+++ b/test/testUtils/assertions/emptyOptions.js
@@ -1,0 +1,17 @@
+const expect = require('expect.js');
+const isEmpty = require("lodash/isEmpty");
+const cloneDeep = require('lodash/cloneDeep');
+const utils = require('../../../cloudinary').utils;
+
+expect.Assertion.prototype.emptyOptions = function () {
+  var actual, options, public_id;
+  [public_id, options] = this.obj;
+  actual = cloneDeep(options);
+  utils.url(public_id, actual);
+  this.assert(isEmpty(actual), function () {
+    return `expected '${public_id}' and ${JSON.stringify(options)} to produce empty options but got ${JSON.stringify(actual)}`;
+  }, function () {
+    return `expected '${public_id}' and ${JSON.stringify(options)} not to produce empty options`;
+  });
+  return this;
+};

--- a/test/testUtils/assertions/produceUrl.js
+++ b/test/testUtils/assertions/produceUrl.js
@@ -1,12 +1,12 @@
 const expect = require('expect.js');
 const cloneDeep = require('lodash/cloneDeep');
-const utils = require('../../../cloudinary');
+const cloudinary = require('../../../cloudinary');
 
 expect.Assertion.prototype.produceUrl = function (url) {
   var actual, actualOptions, options, public_id;
   [public_id, options] = this.obj;
   actualOptions = cloneDeep(options);
-  actual = utils.url(public_id, actualOptions);
+  actual = cloudinary.url(public_id, actualOptions);
   this.assert(actual.match(url), function () {
     return `expected '${public_id}' and ${JSON.stringify(options)} to produce '${url}' but got '${actual}'`;
   }, function () {

--- a/test/testUtils/assertions/produceUrl.js
+++ b/test/testUtils/assertions/produceUrl.js
@@ -1,0 +1,16 @@
+const expect = require('expect.js');
+const cloneDeep = require('lodash/cloneDeep');
+const utils = require('../../../cloudinary');
+
+expect.Assertion.prototype.produceUrl = function (url) {
+  var actual, actualOptions, options, public_id;
+  [public_id, options] = this.obj;
+  actualOptions = cloneDeep(options);
+  actual = utils.url(public_id, actualOptions);
+  this.assert(actual.match(url), function () {
+    return `expected '${public_id}' and ${JSON.stringify(options)} to produce '${url}' but got '${actual}'`;
+  }, function () {
+    return `expected '${public_id}' and ${JSON.stringify(options)} not to produce '${url}' but got '${actual}'`;
+  });
+  return this;
+};

--- a/test/testUtils/testBootstrap.js
+++ b/test/testUtils/testBootstrap.js
@@ -1,0 +1,7 @@
+const glob = require('glob');
+const path = require('path');
+
+// Import all assertion extensions in /test/testUtils/assertions
+glob.sync(`${__dirname}/assertions/*.js`).forEach(function (file) {
+  require(path.resolve(file));
+});


### PR DESCRIPTION
- Move all custom assertions to their own files
- Prepare a testBootstrap.js file for future use (as an entry-point for all tests)
- Clean up some error messages