### PR TITLE
Rename utility function "only"

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -4,7 +4,7 @@ var utils = require("./utils");
 var call_api = require("./api_client/call_api");
 
 var extend = utils.extend,
-    only = utils.only;
+    pickOnlyExistingValues = utils.pickOnlyExistingValues;
 
 
 var TRANSFORMATIONS_URI = "transformations";
@@ -12,7 +12,7 @@ var TRANSFORMATIONS_URI = "transformations";
 function deleteResourcesParams(options) {
   var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-  return extend(params, only(options, "keep_original", "invalidate", "next_cursor", "transformations"));
+  return extend(params, pickOnlyExistingValues(options, "keep_original", "invalidate", "next_cursor", "transformations"));
 }
 
 exports.ping = function ping(callback) {
@@ -48,7 +48,7 @@ exports.resources = function resources(callback) {
   if (options.start_at != null && Object.prototype.toString.call(options.start_at) === '[object Date]') {
     options.start_at = options.start_at.toUTCString();
   }
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at"), callback, options);
 };
 
 exports.resources_by_tag = function resources_by_tag(tag, callback) {
@@ -58,7 +58,7 @@ exports.resources_by_tag = function resources_by_tag(tag, callback) {
       uri = void 0;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "tags", tag];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
 };
 
 exports.resources_by_context = function resources_by_context(key, value, callback) {
@@ -69,7 +69,7 @@ exports.resources_by_context = function resources_by_context(key, value, callbac
       uri = void 0;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "context"];
-  params = only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations");
   params.key = key;
   if (value != null) {
     params.value = value;
@@ -84,7 +84,7 @@ exports.resources_by_moderation = function resources_by_moderation(kind, status,
       uri = void 0;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "moderations", kind, status];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
 };
 
 exports.resources_by_ids = function resources_by_ids(public_ids, callback) {
@@ -97,7 +97,7 @@ exports.resources_by_ids = function resources_by_ids(public_ids, callback) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type];
-  params = only(options, "tags", "context", "moderations");
+  params = pickOnlyExistingValues(options, "tags", "context", "moderations");
   params["public_ids[]"] = public_ids;
   return call_api("get", uri, params, callback, options);
 };
@@ -111,7 +111,7 @@ exports.resource = function resource(public_id, callback) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, only(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback) {
@@ -220,7 +220,7 @@ exports.delete_derived_by_transformation = function delete_derived_by_transforma
   uri = "resources/" + resource_type + "/" + type;
   params = extend({
     "public_ids[]": public_ids
-  }, only(options, "invalidate"));
+  }, pickOnlyExistingValues(options, "invalidate"));
   params.keep_original = true;
   params.transformations = utils.build_eager(transformations);
   return call_api("delete", uri, params, callback, options);
@@ -233,20 +233,20 @@ exports.tags = function tags(callback) {
       uri = void 0;
   resource_type = options.resource_type || "image";
   uri = ["tags", resource_type];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "prefix"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix"), callback, options);
 };
 
 exports.transformations = function transformations(callback) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-  var params = only(options, "next_cursor", "max_results", "named");
+  var params = pickOnlyExistingValues(options, "next_cursor", "max_results", "named");
   return call_api("get", TRANSFORMATIONS_URI, params, callback, options);
 };
 
 exports.transformation = function transformation(transformationName, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-  var params = only(options, "next_cursor", "max_results");
+  var params = pickOnlyExistingValues(options, "next_cursor", "max_results");
   params.transformation = utils.build_eager(transformationName);
   return call_api("get", TRANSFORMATIONS_URI, params, callback, options);
 };
@@ -262,7 +262,7 @@ exports.delete_transformation = function delete_transformation(transformationNam
 exports.update_transformation = function update_transformation(transformationName, updates, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
-  var params = only(updates, "allowed_for_strict");
+  var params = pickOnlyExistingValues(updates, "allowed_for_strict");
   params.transformation = utils.build_eager(transformationName);
   if (updates.unsafe_update != null) {
     params.unsafe_update = utils.build_eager(updates.unsafe_update);
@@ -281,7 +281,7 @@ exports.create_transformation = function create_transformation(name, definition,
 exports.upload_presets = function upload_presets(callback) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-  return call_api("get", ["upload_presets"], only(options, "next_cursor", "max_results"), callback, options);
+  return call_api("get", ["upload_presets"], pickOnlyExistingValues(options, "next_cursor", "max_results"), callback, options);
 };
 
 exports.upload_preset = function upload_preset(name, callback) {
@@ -306,7 +306,7 @@ exports.update_upload_preset = function update_upload_preset(name, callback) {
   var params = void 0,
       uri = void 0;
   uri = ["upload_presets", name];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id", "live"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), pickOnlyExistingValues(options, "unsigned", "disallow_public_id", "live"));
   return call_api("put", uri, params, callback, options);
 };
 
@@ -316,7 +316,7 @@ exports.create_upload_preset = function create_upload_preset(callback) {
   var params = void 0,
       uri = void 0;
   uri = ["upload_presets"];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id", "live"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), pickOnlyExistingValues(options, "name", "unsigned", "disallow_public_id", "live"));
   return call_api("post", uri, params, callback, options);
 };
 
@@ -348,7 +348,7 @@ exports.upload_mappings = function upload_mappings(callback) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   var params = void 0;
-  params = only(options, "next_cursor", "max_results");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results");
   return call_api("get", "upload_mappings", params, callback, options);
 };
 
@@ -375,7 +375,7 @@ exports.update_upload_mapping = function update_upload_mapping(name, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
   var params = void 0;
-  params = only(options, "template");
+  params = pickOnlyExistingValues(options, "template");
   params.folder = name;
   return call_api("put", 'upload_mappings', params, callback, options);
 };
@@ -384,7 +384,7 @@ exports.create_upload_mapping = function create_upload_mapping(name, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
   var params = void 0;
-  params = only(options, "template");
+  params = pickOnlyExistingValues(options, "template");
   params.folder = name;
   return call_api("post", 'upload_mappings', params, callback, options);
 };
@@ -395,7 +395,7 @@ function publishResource(byKey, value, callback) {
   var params = void 0,
       resource_type = void 0,
       uri = void 0;
-  params = only(options, "type", "invalidate", "overwrite");
+  params = pickOnlyExistingValues(options, "type", "invalidate", "overwrite");
   params[byKey] = value;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "publish_resources"];
@@ -512,7 +512,7 @@ exports.update_resources_access_mode_by_ids = function update_resources_access_m
 exports.add_metadata_field = function add_metadata_field(field, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-  var params = only(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
   options.content_type = "json";
   return call_api("post", ["metadata_fields"], params, callback, options);
 };
@@ -587,7 +587,7 @@ exports.metadata_field_by_field_id = function metadata_field_by_field_id(externa
 exports.update_metadata_field = function update_metadata_field(external_id, field, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
-  var params = only(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", external_id], params, callback, options);
 };
@@ -611,7 +611,7 @@ exports.update_metadata_field = function update_metadata_field(external_id, fiel
 exports.update_metadata_field_datasource = function update_metadata_field_datasource(field_external_id, entries_external_id, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
-  var params = only(entries_external_id, "values");
+  var params = pickOnlyExistingValues(entries_external_id, "values");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", field_external_id, "datasource"], params, callback, options);
 };

--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -39,7 +39,8 @@ var build_upload_params = utils.build_upload_params,
     includes = utils.includes,
     isObject = utils.isObject,
     isRemoteUrl = utils.isRemoteUrl,
-    merge = utils.merge;
+    merge = utils.merge,
+    pickOnlyExistingValues = utils.pickOnlyExistingValues;
 
 
 exports.unsigned_upload_stream = function unsigned_upload_stream(upload_preset, callback) {
@@ -252,7 +253,7 @@ exports.text = function text(content, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
   return call_api("text", callback, options, function () {
-    var textParams = utils.only.apply(utils, [options].concat(TEXT_PARAMS));
+    var textParams = pickOnlyExistingValues.apply(undefined, [options].concat(TEXT_PARAMS));
     var params = _extends({
       timestamp: utils.timestamp(),
       text: content

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -641,7 +641,7 @@ var URL_KEYS = ['api_secret', 'auth_token', 'cdn_subdomain', 'cloud_name', 'cnam
  */
 
 function extractUrlParams(options) {
-  return utils.only.apply(utils, [options].concat(URL_KEYS));
+  return pickOnlyExistingValues.apply(undefined, [options].concat(URL_KEYS));
 }
 
 /**
@@ -651,7 +651,7 @@ function extractUrlParams(options) {
  */
 
 function extractTransformationParams(options) {
-  return utils.only.apply(utils, [options].concat(_toConsumableArray(TRANSFORMATION_PARAMS)));
+  return pickOnlyExistingValues.apply(undefined, [options].concat(_toConsumableArray(TRANSFORMATION_PARAMS)));
 }
 
 /**
@@ -1136,7 +1136,7 @@ exports.html_attrs = function html_attrs(attrs) {
 var CLOUDINARY_JS_CONFIG_PARAMS = ['api_key', 'cloud_name', 'private_cdn', 'secure_distribution', 'cdn_subdomain'];
 
 function cloudinary_js_config() {
-  var params = utils.only.apply(utils, [config()].concat(CLOUDINARY_JS_CONFIG_PARAMS));
+  var params = pickOnlyExistingValues.apply(undefined, [config()].concat(CLOUDINARY_JS_CONFIG_PARAMS));
   return `<script type='text/javascript'>\n$.cloudinary.config(${JSON.stringify(params)});\n</script>`;
 }
 
@@ -1328,7 +1328,7 @@ function generate_responsive_breakpoints_string(breakpoints) {
 function build_streaming_profiles_param() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-  var params = utils.only(options, "display_name", "representations");
+  var params = pickOnlyExistingValues(options, "display_name", "representations");
   if (isArray(params.representations)) {
     params.representations = JSON.stringify(params.representations.map(function (r) {
       return {
@@ -1395,7 +1395,7 @@ function present(value) {
  * @return {object} A new object with the required keys and values.
  */
 
-function only(source) {
+function pickOnlyExistingValues(source) {
   var result = {};
   if (source) {
     for (var _len2 = arguments.length, keys = Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
@@ -1486,7 +1486,8 @@ exports.generate_responsive_breakpoints_string = generate_responsive_breakpoints
 exports.build_streaming_profiles_param = build_streaming_profiles_param;
 exports.hashToParameters = hashToParameters;
 exports.present = present;
-exports.only = only;
+exports.only = pickOnlyExistingValues; // for backwards compatibility
+exports.pickOnlyExistingValues = pickOnlyExistingValues;
 exports.jsonArrayParam = jsonArrayParam;
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,12 +1,12 @@
 const utils = require("./utils");
 const call_api = require("./api_client/call_api");
 
-const { extend, only } = utils;
+const { extend, pickOnlyExistingValues } = utils;
 
 const TRANSFORMATIONS_URI = "transformations";
 
 function deleteResourcesParams(options, params = {}) {
-  return extend(params, only(options, "keep_original", "invalidate", "next_cursor", "transformations"));
+  return extend(params, pickOnlyExistingValues(options, "keep_original", "invalidate", "next_cursor", "transformations"));
 }
 
 exports.ping = function ping(callback, options = {}) {
@@ -32,21 +32,21 @@ exports.resources = function resources(callback, options = {}) {
   if ((options.start_at != null) && Object.prototype.toString.call(options.start_at) === '[object Date]') {
     options.start_at = options.start_at.toUTCString();
   }
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at"), callback, options);
 };
 
 exports.resources_by_tag = function resources_by_tag(tag, callback, options = {}) {
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "tags", tag];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
 };
 
 exports.resources_by_context = function resources_by_context(key, value, callback, options = {}) {
   let params, resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "context"];
-  params = only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations");
   params.key = key;
   if (value != null) {
     params.value = value;
@@ -58,7 +58,7 @@ exports.resources_by_moderation = function resources_by_moderation(kind, status,
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "moderations", kind, status];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations"), callback, options);
 };
 
 exports.resources_by_ids = function resources_by_ids(public_ids, callback, options = {}) {
@@ -66,7 +66,7 @@ exports.resources_by_ids = function resources_by_ids(public_ids, callback, optio
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type];
-  params = only(options, "tags", "context", "moderations");
+  params = pickOnlyExistingValues(options, "tags", "context", "moderations");
   params["public_ids[]"] = public_ids;
   return call_api("get", uri, params, callback, options);
 };
@@ -76,7 +76,7 @@ exports.resource = function resource(public_id, callback, options = {}) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, only(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback, options = {}) {
@@ -159,7 +159,7 @@ exports.delete_derived_by_transformation = function delete_derived_by_transforma
   uri = "resources/" + resource_type + "/" + type;
   params = extend({
     "public_ids[]": public_ids,
-  }, only(options, "invalidate"));
+  }, pickOnlyExistingValues(options, "invalidate"));
   params.keep_original = true;
   params.transformations = utils.build_eager(transformations);
   return call_api("delete", uri, params, callback, options);
@@ -169,16 +169,16 @@ exports.tags = function tags(callback, options = {}) {
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["tags", resource_type];
-  return call_api("get", uri, only(options, "next_cursor", "max_results", "prefix"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix"), callback, options);
 };
 
 exports.transformations = function transformations(callback, options = {}) {
-  const params = only(options, "next_cursor", "max_results", "named");
+  const params = pickOnlyExistingValues(options, "next_cursor", "max_results", "named");
   return call_api("get", TRANSFORMATIONS_URI, params, callback, options);
 };
 
 exports.transformation = function transformation(transformationName, callback, options = {}) {
-  const params = only(options, "next_cursor", "max_results");
+  const params = pickOnlyExistingValues(options, "next_cursor", "max_results");
   params.transformation = utils.build_eager(transformationName);
   return call_api("get", TRANSFORMATIONS_URI, params, callback, options);
 };
@@ -190,7 +190,7 @@ exports.delete_transformation = function delete_transformation(transformationNam
 };
 
 exports.update_transformation = function update_transformation(transformationName, updates, callback, options = {}) {
-  const params = only(updates, "allowed_for_strict");
+  const params = pickOnlyExistingValues(updates, "allowed_for_strict");
   params.transformation = utils.build_eager(transformationName);
   if (updates.unsafe_update != null) {
     params.unsafe_update = utils.build_eager(updates.unsafe_update);
@@ -205,7 +205,7 @@ exports.create_transformation = function create_transformation(name, definition,
 };
 
 exports.upload_presets = function upload_presets(callback, options = {}) {
-  return call_api("get", ["upload_presets"], only(options, "next_cursor", "max_results"), callback, options);
+  return call_api("get", ["upload_presets"], pickOnlyExistingValues(options, "next_cursor", "max_results"), callback, options);
 };
 
 exports.upload_preset = function upload_preset(name, callback, options = {}) {
@@ -223,14 +223,14 @@ exports.delete_upload_preset = function delete_upload_preset(name, callback, opt
 exports.update_upload_preset = function update_upload_preset(name, callback, options = {}) {
   let params, uri;
   uri = ["upload_presets", name];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "unsigned", "disallow_public_id", "live"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), pickOnlyExistingValues(options, "unsigned", "disallow_public_id", "live"));
   return call_api("put", uri, params, callback, options);
 };
 
 exports.create_upload_preset = function create_upload_preset(callback, options = {}) {
   let params, uri;
   uri = ["upload_presets"];
-  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), only(options, "name", "unsigned", "disallow_public_id", "live"));
+  params = utils.merge(utils.clear_blank(utils.build_upload_params(options)), pickOnlyExistingValues(options, "name", "unsigned", "disallow_public_id", "live"));
   return call_api("post", uri, params, callback, options);
 };
 
@@ -254,7 +254,7 @@ exports.delete_folder = function delete_folder(path, callback, options = {}) {
 
 exports.upload_mappings = function upload_mappings(callback, options = {}) {
   let params;
-  params = only(options, "next_cursor", "max_results");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results");
   return call_api("get", "upload_mappings", params, callback, options);
 };
 
@@ -275,21 +275,21 @@ exports.delete_upload_mapping = function delete_upload_mapping(name, callback, o
 
 exports.update_upload_mapping = function update_upload_mapping(name, callback, options = {}) {
   let params;
-  params = only(options, "template");
+  params = pickOnlyExistingValues(options, "template");
   params.folder = name;
   return call_api("put", 'upload_mappings', params, callback, options);
 };
 
 exports.create_upload_mapping = function create_upload_mapping(name, callback, options = {}) {
   let params;
-  params = only(options, "template");
+  params = pickOnlyExistingValues(options, "template");
   params.folder = name;
   return call_api("post", 'upload_mappings', params, callback, options);
 };
 
 function publishResource(byKey, value, callback, options = {}) {
   let params, resource_type, uri;
-  params = only(options, "type", "invalidate", "overwrite");
+  params = pickOnlyExistingValues(options, "type", "invalidate", "overwrite");
   params[byKey] = value;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "publish_resources"];
@@ -391,7 +391,7 @@ exports.update_resources_access_mode_by_ids = function update_resources_access_m
  * @return {Object}
  */
 exports.add_metadata_field = function add_metadata_field(field, callback, options = {}) {
-  const params = only(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
   options.content_type = "json";
   return call_api("post", ["metadata_fields"], params, callback, options);
 };
@@ -458,7 +458,7 @@ exports.metadata_field_by_field_id = function metadata_field_by_field_id(externa
  * @return {Object}
  */
 exports.update_metadata_field = function update_metadata_field(external_id, field, callback, options = {}) {
-  const params = only(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", external_id], params, callback, options);
 };
@@ -480,7 +480,7 @@ exports.update_metadata_field = function update_metadata_field(external_id, fiel
  * @return {Object}
  */
 exports.update_metadata_field_datasource = function update_metadata_field_datasource(field_external_id, entries_external_id, callback, options = {}) {
-  const params = only(entries_external_id, "values");
+  const params = pickOnlyExistingValues(entries_external_id, "values");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", field_external_id, "datasource"], params, callback, options);
 };

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -21,6 +21,7 @@ const {
   isObject,
   isRemoteUrl,
   merge,
+  pickOnlyExistingValues,
 } = utils;
 
 exports.unsigned_upload_stream = function unsigned_upload_stream(upload_preset, callback, options = {}) {
@@ -198,7 +199,7 @@ const TEXT_PARAMS = ["public_id", "font_family", "font_size", "font_color", "tex
 
 exports.text = function text(content, callback, options = {}) {
   return call_api("text", callback, options, function () {
-    let textParams = utils.only(options, ...TEXT_PARAMS);
+    let textParams = pickOnlyExistingValues(options, ...TEXT_PARAMS);
     let params = {
       timestamp: utils.timestamp(),
       text: content,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -580,7 +580,7 @@ const URL_KEYS = [
  */
 
 function extractUrlParams(options) {
-  return utils.only(options, ...URL_KEYS);
+  return pickOnlyExistingValues(options, ...URL_KEYS);
 }
 
 /**
@@ -590,7 +590,7 @@ function extractUrlParams(options) {
  */
 
 function extractTransformationParams(options) {
-  return utils.only(options, ...TRANSFORMATION_PARAMS);
+  return pickOnlyExistingValues(options, ...TRANSFORMATION_PARAMS);
 }
 
 /**
@@ -1041,7 +1041,7 @@ exports.html_attrs = function html_attrs(attrs) {
 const CLOUDINARY_JS_CONFIG_PARAMS = ['api_key', 'cloud_name', 'private_cdn', 'secure_distribution', 'cdn_subdomain'];
 
 function cloudinary_js_config() {
-  let params = utils.only(config(), ...CLOUDINARY_JS_CONFIG_PARAMS);
+  let params = pickOnlyExistingValues(config(), ...CLOUDINARY_JS_CONFIG_PARAMS);
   return `<script type='text/javascript'>\n$.cloudinary.config(${JSON.stringify(params)});\n</script>`;
 }
 
@@ -1218,7 +1218,7 @@ function generate_responsive_breakpoints_string(breakpoints) {
 }
 
 function build_streaming_profiles_param(options = {}) {
-  let params = utils.only(options, "display_name", "representations");
+  let params = pickOnlyExistingValues(options, "display_name", "representations");
   if (isArray(params.representations)) {
     params.representations = JSON.stringify(params.representations.map(
       r => ({
@@ -1275,7 +1275,7 @@ function present(value) {
  * @return {object} A new object with the required keys and values.
  */
 
-function only(source, ...keys) {
+function pickOnlyExistingValues(source, ...keys) {
   let result = {};
   if (source) {
     for (let j = 0; j < keys.length; j++) {
@@ -1360,7 +1360,8 @@ exports.generate_responsive_breakpoints_string = generate_responsive_breakpoints
 exports.build_streaming_profiles_param = build_streaming_profiles_param;
 exports.hashToParameters = hashToParameters;
 exports.present = present;
-exports.only = only;
+exports.only = pickOnlyExistingValues; // for backwards compatibility
+exports.pickOnlyExistingValues = pickOnlyExistingValues;
 exports.jsonArrayParam = jsonArrayParam;
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -14,7 +14,7 @@ const generateBreakpoints = require(`../${helper.libPath}/utils/generateBreakpoi
 const { srcsetUrl, generateSrcsetAttribute } = require(`../${helper.libPath}/utils/srcsetUtils`);
 
 const utils = cloudinary.utils;
-const { clone, isString, merge, only } = utils;
+const { clone, isString, merge, pickOnlyExistingValues } = utils;
 const { sharedExamples, itBehavesLike, test_cloudinary_url } = helper;
 
 const TEST_TAG = helper.TEST_TAG;
@@ -1315,7 +1315,7 @@ describe("utils", function () {
       eager_async: "1",
     };
     params = utils.build_upload_params(options);
-    expected = only(params, ...Object.keys(options));
+    expected = pickOnlyExistingValues(params, ...Object.keys(options));
     actual = {
       backup: 1,
       use_filename: 0,


### PR DESCRIPTION
This is an improvement on the name of the utility function 'only'.

The function does two distinct things,
1. implements 'pick' from lodash
2. omits undefined and null from the result

Finding a good name for a function that does two things is always difficult, I suggest we start by giving it a clearer name, and maybe in the future think about splitting it up