### PR TITLE
Add tests for new OCR features

### DIFF
--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -33,7 +33,8 @@ const {
   PUBLIC_ID_6,
   PUBLIC_ID_BACKUP_1,
   PUBLIC_ID_BACKUP_2,
-  PUBLIC_ID_BACKUP_3
+  PUBLIC_ID_BACKUP_3,
+  PUBLIC_ID_OCR_1
 } = PUBLIC_IDS;
 
 const {
@@ -811,6 +812,32 @@ describe("api", function () {
         });
       });
     });
+    describe(":ocr", function () {
+      before(async function () {
+        await uploadImage({
+          public_id: PUBLIC_ID_OCR_1,
+          tags: [TEST_TAG]
+        })
+      });
+      it("should support requesting ocr when updating", async function () {
+        // Update an image with ocr parameter
+        const ocrType = "adv_ocr";
+        const updateResult = await API_V2.update(PUBLIC_ID_OCR_1, { ocr: ocrType });
+
+        // Ensure result includes a ocr with correct value
+        expect(updateResult).not.to.be.empty();
+        expect(updateResult.info).to.be.an("object");
+        expect(updateResult.info.ocr).to.be.an("object");
+        expect(updateResult.info.ocr).to.have.property(ocrType);
+      });
+      it("should return 'Illegal value' errors for unknown ocr types", function () {
+        this.timeout(TIMEOUT.MEDIUM);
+        return API_V2.update(PUBLIC_ID_OCR_1, {ocr: 'illegal'})
+          .then(
+            () => expect().fail()
+          ).catch(({ error }) => expect(error.message).to.contain("Illegal value"));
+      });
+    });
     it("should support setting manual moderation status", function() {
       this.timeout(TIMEOUT.LONG);
       return uploadImage({
@@ -821,15 +848,6 @@ describe("api", function () {
         .catch((err) => {
           console.og(err);
         });
-    });
-    it("should support requesting ocr info", function () {
-      this.timeout(TIMEOUT.MEDIUM);
-      return uploadImage()
-        .then(upload_result => cloudinary.v2.api.update(upload_result.public_id, {
-          ocr: "illegal"
-        })).then(
-          () => expect().fail()
-        ).catch(({ error }) => expect(error.message).to.contain("Illegal value"));
     });
     it("should support requesting raw conversion", function () {
       this.timeout(TIMEOUT.MEDIUM);

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -552,14 +552,6 @@ describe("uploader", function () {
       expect(result.moderation[0].kind).to.eql("manual");
     });
   });
-  it("should support requesting ocr analysis", function () {
-    return cloudinary.v2.uploader.upload(IMAGE_FILE, {
-      ocr: "adv_ocr",
-      tags: UPLOAD_TAGS
-    }).then(function (result) {
-      expect(result.info.ocr).to.have.key("adv_ocr");
-    });
-  });
   it("should support requesting raw conversion", function () {
     return cloudinary.v2.uploader.upload(RAW_FILE, {
       raw_convert: "illegal",
@@ -1036,6 +1028,40 @@ describe("uploader", function () {
         expect(Date.parse(response_acl[0].start)).to.be(Date.parse(acl.start));
         expect(Date.parse(response_acl[0].end)).to.be(Date.parse(acl.end));
       });
+    });
+  });
+  describe(":ocr", function () {
+    const ocrType = "adv_ocr";
+
+    it("should support requesting ocr when uploading", async function () {
+      // Upload an image and request ocr details in the response
+      const result = await UPLOADER_V2.upload(IMAGE_FILE, {ocr: ocrType, tags: [TEST_TAG]});
+
+      // Ensure result includes properly structured ocr details
+      expect(result).not.to.be.empty();
+      expect(result.info).to.be.an("object");
+      expect(result.info.ocr).to.be.an("object");
+      expect(result.info.ocr).to.have.key(ocrType);
+      expect(result.info.ocr[ocrType]).to.have.key("status");
+      expect(result.info.ocr[ocrType]).to.have.key("data");
+    });
+
+    it("should support ocr parameter in explicit", async function () {
+      // Upload an image
+      const uploadResult = await UPLOADER_V2.upload(IMAGE_FILE, {
+        tags: [TEST_TAG]
+      });
+
+      // Call explicit on the uploaded image with ocr parameter
+      const explicitResult = await UPLOADER_V2.explicit(uploadResult.public_id, {
+        ocr: ocrType,
+        "tags": [TEST_TAG],
+        type: "upload"
+      });
+
+      // Ensure result isn't an error
+      expect(explicitResult).not.to.be.empty();
+      expect(explicitResult.public_id).to.eql(uploadResult.public_id);
     });
   });
 

--- a/test/testUtils/testConstants.js
+++ b/test/testUtils/testConstants.js
@@ -34,7 +34,8 @@ module.exports = {
     PUBLIC_ID_6: `${PUBLIC_ID}_6`,
     PUBLIC_ID_BACKUP_1: `${PUBLIC_ID_PREFIX}backup_1${Date.now()}`,
     PUBLIC_ID_BACKUP_2: `${PUBLIC_ID_PREFIX}backup_2${Date.now()}`,
-    PUBLIC_ID_BACKUP_3: `${PUBLIC_ID_PREFIX}backup_3${Date.now()}`
+    PUBLIC_ID_BACKUP_3: `${PUBLIC_ID_PREFIX}backup_3${Date.now()}`,
+    PUBLIC_ID_OCR_1: `${PUBLIC_ID_PREFIX}ocr_1${Date.now()}`
 
   },
   PRESETS: {

--- a/test/unit/cloudinary_spec.js
+++ b/test/unit/cloudinary_spec.js
@@ -141,6 +141,28 @@ describe("cloudinary", function () {
     expect(options).to.eql({});
     expect(result).to.eql("http://res.cloudinary.com/test123/image/upload/g_center,o_20,p_a,q_0.4,r_3,x_1,y_2/test");
   });
+  describe(":gravity", function () {
+    it("should support 'ocr_text' as a value for gravity parameter", function () {
+      const options = {
+        gravity: "ocr_text",
+        crop: "crop",
+        width: 0.5
+      };
+      const result = cloudinary.utils.url("test", options);
+      expect(result).to.eql("http://res.cloudinary.com/test123/image/upload/c_crop,g_ocr_text,w_0.5/test");
+      expect(options).to.eql({});
+    });
+    it("should support 'auto:ocr_text' as a value for gravity parameter", function () {
+      const options = {
+        gravity: "auto:ocr_text",
+        crop: "crop",
+        width: 0.5
+      };
+      const result = cloudinary.utils.url("test", options);
+      expect(result).to.eql("http://res.cloudinary.com/test123/image/upload/c_crop,g_auto:ocr_text,w_0.5/test");
+      expect(options).to.eql({});
+    });
+  });
   describe(":quality", function () {
     var upload_path = "http://res.cloudinary.com/test123/image/upload";
     it("support a percent value", function () {

--- a/test/unit/tags/image_spec.js
+++ b/test/unit/tags/image_spec.js
@@ -62,6 +62,18 @@ describe('image helper', function () {
       dpr: "auto"
     })).to.eql(`<img class='cld-hidpi' data-src='${UPLOAD_PATH}/dpr_auto/hello.png'/>`);
   });
+  it("should support 'blur_region' value for effect parameter", function () {
+    expect(cloudinary.image("hello", {
+      effect: ["blur_region", 5000],
+      gravity: "ocr_text"
+    })).to.eql(`<img src='${UPLOAD_PATH}/e_blur_region:5000,g_ocr_text/hello' />`);
+  });
+  it("should support 'pixelate_region' value for effect parameter", function () {
+    expect(cloudinary.image("hello", {
+      effect: "pixelate_region",
+      gravity: "ocr_text"
+    })).to.eql(`<img src='${UPLOAD_PATH}/e_pixelate_region,g_ocr_text/hello' />`);
+  });
   it("should support e_art:incognito transformation", function () {
     expect(cloudinary.image("hello", {
       format: "png",


### PR DESCRIPTION
- Support `ocr` in data structure returned from upload
- Support `ocr` parameter in Upload API (`upload()` and `explicit()`) and Admin API (`update()`)
- Support `gravity` values `ocr_text[:<engine>]` and `auto:ocr_text`
- Support new `pixelate_region` and `blur_region` effects (with gravity support)