### PR TITLE
Add support for power operator in expressions

### DIFF
--- a/lib-es5/utils/consts.js
+++ b/lib-es5/utils/consts.js
@@ -24,7 +24,8 @@ var CONDITIONAL_OPERATORS = {
   "*": "mul",
   "/": "div",
   "+": "add",
-  "-": "sub"
+  "-": "sub",
+  "^": "pow"
 };
 
 var SIMPLE_PARAMS = [["audio_codec", "ac"], ["audio_frequency", "af"], ["bit_rate", 'br'], ["color_space", "cs"], ["default_image", "d"], ["delay", "dl"], ["density", "dn"], ["duration", "du"], ["end_offset", "eo"], ["fetch_format", "f"], ["gravity", "g"], ["page", "pg"], ["prefix", "p"], ["start_offset", "so"], ["streaming_profile", "sp"], ["video_codec", "vc"], ["video_sampling", "vs"]];

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -138,7 +138,7 @@ function normalize_expression(expression) {
     return expression;
   }
 
-  var operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
+  var operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\^|\\+|\\*";
   var operatorsPattern = "((" + operators + ")(?=[ _]))";
   var operatorsReplaceRE = new RegExp(operatorsPattern, "g");
   expression = expression.replace(operatorsReplaceRE, function (match) {

--- a/lib/utils/consts.js
+++ b/lib/utils/consts.js
@@ -23,6 +23,7 @@ const CONDITIONAL_OPERATORS = {
   "/": "div",
   "+": "add",
   "-": "sub",
+  "^": "pow",
 };
 
 let SIMPLE_PARAMS = [

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -128,7 +128,7 @@ function normalize_expression(expression) {
     return expression;
   }
 
-  const operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
+  const operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\^|\\+|\\*";
   const operatorsPattern = "((" + operators + ")(?=[ _]))";
   const operatorsReplaceRE = new RegExp(operatorsPattern, "g");
   expression = expression.replace(operatorsReplaceRE, match => CONDITIONAL_OPERATORS[match]);

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1084,6 +1084,19 @@ describe("utils", function () {
           },
         }, `http://res.cloudinary.com/${cloud_name}/image/upload/c_scale,l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/sample`, {});
       });
+      it("should support power operator", function () {
+        var options, t;
+        options = {
+          transformation: [
+            {
+              $small: 150,
+              $big: "$small ^ 1.5",
+            },
+          ],
+        };
+        t = cloudinary.utils.generate_transformation_string(options);
+        expect(t).to.eql("$big_$small_pow_1.5,$small_150");
+      });
     });
     describe("text", function () {
       var text_encoded, text_layer;


### PR DESCRIPTION
Support the `pow` (power) arithmetic operator in SDKs, in addition to operators like `mul` (multiply), and `div` (divide). 

The power operator can be used with internal and user defined variables to calculate numeric values. User specifies the power operator using the `^` sign. For example `$small ^ 1.5`

