### PR TITLE
Make sure Uploader tests cleanup after themselves

### DIFF
--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -29,6 +29,8 @@ exports.ICON_FILE = "test/.resources/favicon.ico";
 exports.VIDEO_URL = "http://res.cloudinary.com/demo/video/upload/dog.mp4";
 exports.IMAGE_URL = "http://res.cloudinary.com/demo/image/upload/sample";
 
+const { TEST_TAG } = require('./testUtils/testConstants').TAGS;
+
 exports.SAMPLE_VIDEO_SOURCES = [
   {
     type: 'mp4',
@@ -234,7 +236,11 @@ exports.setupCache = function () {
  * @param {object} options Optional options to use when uploading the test image
  * @returns {object} A response object returned from the upload API
  */
-exports.uploadImage = function (options) {
+exports.uploadImage = function (options = {}) {
+  // Ensure that options at the very least contains the TEST_TAG
+  options.tags = options.tags || [];
+  if (!options.tags.includes(TEST_TAG)) options.tags.push(TEST_TAG);
+
   return cloudinary.v2.uploader.upload(exports.IMAGE_FILE, options);
 };
 

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -229,9 +229,11 @@ exports.setupCache = function () {
 };
 
 /**
-  Upload an image to be tested on.
-  @callback the callback receives the public_id of the uploaded image
-*/
+ * Upload an image to be tested on.
+ *
+ * @param {object} options Optional options to use when uploading the test image
+ * @returns {object} A response object returned from the upload API
+ */
 exports.uploadImage = function (options) {
   return cloudinary.v2.uploader.upload(exports.IMAGE_FILE, options);
 };


### PR DESCRIPTION
Many files were uploaded in the tests without properly marking them for cleanup.

This change in `uploadImage` (the helper that uploads the test images) makes sure test images are always tagged with the `TEST_TAG` so they will be deleted in the test teardown.

A separate commit also fixes the docstring for `uploadImage`.