### PR TITLE
Fix typo in destroy method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -943,7 +943,7 @@ declare module 'cloudinary' {
 
             function create_zip(options?: ArchiveApiOptions, callback?: ResponseCallback): Promise<any>;
 
-            function destroy(public_id: string, options?: { resource_types?: ResourceType, type?: DeliveryType, invalidate?: boolean }, callback?: ResponseCallback,): Promise<any>;
+            function destroy(public_id: string, options?: { resource_type?: ResourceType, type?: DeliveryType, invalidate?: boolean }, callback?: ResponseCallback,): Promise<any>;
 
             function destroy(public_id: string, callback?: ResponseCallback,): Promise<any>;
 


### PR DESCRIPTION
`resource_types` should be `resource_type` as documented in https://cloudinary.com/documentation/image_upload_api_reference#optional_parameters-2