### PR TITLE
Allow external PRs to pass Travis tests

### DIFF
--- a/test/cloudinary_spec.js
+++ b/test/cloudinary_spec.js
@@ -816,7 +816,7 @@ describe("cloudinary", function () {
     });
     describe("CLOUDINARY_URL", function () {
       after(function () {
-        process.env.CLOUDINARY_URL = cloudinaryUrlBackup;
+        process.env.CLOUDINARY_URL = cloudinaryUrlBackup || '';
         cloudinary.config(true);
       });
       it("should allow nested values in CLOUDINARY_URL", function () {
@@ -849,7 +849,7 @@ describe("cloudinary", function () {
     });
     describe("CLOUDINARY_ACCOUNT_URL", function () {
       after(function () {
-        process.env.CLOUDINARY_ACCOUNT_URL = accountUrlBackup;
+        process.env.CLOUDINARY_ACCOUNT_URL = accountUrlBackup || '';
         cloudinary.config(true);
       });
       it("should allow nested values in CLOUDINARY_ACCOUNT_URL", function () {

--- a/test/integration/api/provisioning/account_spec.js
+++ b/test/integration/api/provisioning/account_spec.js
@@ -6,7 +6,10 @@ const expect = require("expect.js");
 const cloudinary = require("../../../../cloudinary");
 const TIMEOUT = require('../../../testUtils/testConstants').TIMEOUT;
 
-describe('account API - Provisioning', function () {
+let runOnlyForInternalPRs = process.env.TRAVIS_SECURE_ENV_VARS ? describe : describe.skip;
+
+
+runOnlyForInternalPRs('account API - Provisioning', function () {
   let CLOUD_SECRET;
   let CLOUD_API;
   let CLOUD_NAME;


### PR DESCRIPTION
- Exclude account API tests when tests are running in Travis from a Fork
- Fix string assignment to process.env variable (would incorrectly get the value of "undefined" (as a string)