### PR TITLE
Add a command to run unit tests(without integration tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "types": "types",
   "scripts": {
     "test": "tools/scripts/test.sh",
+    "test:unit" : "mocha --ui bdd -R spec --recursive test/unit",
     "test-with-temp-cloud": "tools/scripts/tests-with-temp-cloud.sh",
     "dtslint": "tools/scripts/ditslint.sh",
     "lint": "tools/scripts/lint.sh",


### PR DESCRIPTION
This change adds a command to run unit tests (without the integration tests).

The command isn't fleshed out yet and is designed for development purposes only.
Maybe if we find better use cases for it later, we can extend it. 