### PR TITLE
Add support for pending, prefix, and sub_account_id to users method

### DIFF
--- a/lib-es5/provisioning/account.js
+++ b/lib-es5/provisioning/account.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var utils = require("../utils");
 var call_account_api = require('../api_client/call_account_api');
+
+var pickOnlyExistingValues = utils.pickOnlyExistingValues;
 
 /**
  * @desc Lists sub-accounts.
@@ -11,6 +14,7 @@ var call_account_api = require('../api_client/call_account_api');
  * @param [options] {object} - See {@link https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters|Configuration parameters} in the SDK documentation.
  * @param [callback] {function}
  */
+
 function sub_accounts(enabled) {
   var ids = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
   var prefix = arguments[2];
@@ -148,9 +152,12 @@ function users(pending, user_ids, prefix, sub_account_id) {
 
   var uri = ['users'];
   var params = {
-    ids: user_ids
+    ids: user_ids,
+    pending,
+    prefix,
+    sub_account_id
   };
-  return call_account_api('GET', uri, params, callback, options);
+  return call_account_api('GET', uri, pickOnlyExistingValues(params, "ids", "pending", "prefix", "sub_account_id"), callback, options);
 }
 
 /**

--- a/lib/provisioning/account.js
+++ b/lib/provisioning/account.js
@@ -1,4 +1,7 @@
+const utils = require("../utils");
 const call_account_api = require('../api_client/call_account_api');
+
+const { pickOnlyExistingValues } = utils;
 
 /**
  * @desc Lists sub-accounts.
@@ -125,9 +128,12 @@ function user(user_id, options = {}, callback) {
 function users(pending, user_ids, prefix, sub_account_id, options = {}, callback) {
   let uri = ['users'];
   let params = {
-    ids: user_ids
+    ids: user_ids,
+    pending,
+    prefix,
+    sub_account_id
   };
-  return call_account_api('GET', uri, params, callback, options);
+  return call_account_api('GET', uri, pickOnlyExistingValues(params, "ids", "pending", "prefix", "sub_account_id"), callback, options);
 }
 
 /**


### PR DESCRIPTION
`users` method of the provisioning API was missing support for the `pending`, `prefix`, and `sub_account_id` parameters.