### PR TITLE
Fixed test for manual moderation status

### DIFF
--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -818,9 +818,7 @@ describe("api", function () {
       }).then(upload_result => cloudinary.v2.api.update(upload_result.public_id, {
         moderation_status: "approved"
       })).then(api_result => expect(api_result.moderation[0].status).to.eql("approved"))
-        .catch((err) => {
-          console.og(err);
-        });
+        .catch((err) => expect().fail(err));
     });
     it("should support requesting ocr info", function () {
       this.timeout(TIMEOUT.MEDIUM);


### PR DESCRIPTION
Previous test would not have registered as failed if it failed, unless the console OG felt like it.