### PR TITLE
Update mocha to mocha@8

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require" : "./test/setup.js",
+  "recursive": true,
+  "retries": 3
+}

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "q": "^1.5.1"
   },
   "devDependencies": {
-    "@types/mocha": "^7.0.2",
-    "@types/node": "^13.5.0",
     "@types/expect.js": "^0.3.29",
+    "@types/mocha": "^8.0.0",
+    "@types/node": "^13.5.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -38,7 +38,7 @@
     "jsdoc": "^3.5.5",
     "jsdom": "^9.12.0",
     "jsdom-global": "2.1.1",
-    "mocha": "^6.2.3",
+    "mocha": "^8.0.1",
     "mock-fs": "^4.12.0",
     "nyc": "^13.3.0",
     "rimraf": "^3.0.0",
@@ -57,7 +57,7 @@
   "types": "types",
   "scripts": {
     "test": "tools/scripts/test.sh",
-    "test:unit": "mocha --recursive test/unit",
+    "test:unit": "mocha \"./test/unit/**/*spec.js\"",
     "test-with-temp-cloud": "tools/scripts/tests-with-temp-cloud.sh",
     "dtslint": "tools/scripts/ditslint.sh",
     "lint": "tools/scripts/lint.sh",

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -141,7 +141,6 @@ function findByAttr(elements, attr, value) {
 
 
 describe("api", function () {
-  this.retries(3);
   var contextKey = `test-key${UNIQUE_JOB_SUFFIX_ID}`;
   before("Verify Configuration", function () {
     let config = cloudinary.config(true);

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -24,7 +24,6 @@ const SEARCH_TAG = 'npm_advanced_search_' + UNIQUE_JOB_SUFFIX_ID;
 
 
 describe("search_api", function () {
-  this.retries(3);
   describe("unit", function () {
     it('should create empty json', function () {
       var query_hash = cloudinary.v2.search.instance().to_query();

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -85,7 +85,6 @@ sharedExamples('archive', function () {
 });
 
 describe("archive", function () {
-  this.retries(3);
   includeContext('archive');
   describe("utils", function () {
     describe('.generate_zip_download_url', function () {

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -40,7 +40,6 @@ const {
 require('jsdom-global')();
 
 describe("uploader", function () {
-  this.retries(3);
   before("Verify Configuration", function () {
     var config = cloudinary.config(true);
     if (!(config.api_key && config.api_secret)) {

--- a/test/integration/streaming_profiles_spec.js
+++ b/test/integration/streaming_profiles_spec.js
@@ -1,8 +1,8 @@
 const keys = require('lodash/keys');
 const Q = require('q');
-const cloudinary = require("../cloudinary");
-const helper = require("./spechelper");
-const TIMEOUT = require('./testUtils/testConstants').TIMEOUT;
+const cloudinary = require("../../cloudinary");
+const helper = require("../spechelper");
+const TIMEOUT = require('../testUtils/testConstants').TIMEOUT;
 const api = cloudinary.v2.api;
 
 describe('Cloudinary::Api', function () {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---require './test/setup.js'
--R spec
---ui bdd

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,9 +1,10 @@
-global.expect = require('expect.js');
-require('./testUtils/testBootstrap');
-
-
 require('dotenv').load({
   silent: true
 });
 
+if (!process.env.CLOUDINARY_URL) {
+  throw 'Could not start tests - Cloudianry URL is undefined'
+}
 
+global.expect = require('expect.js');
+require('./testUtils/testBootstrap');

--- a/test/testUtils/testConstants.js
+++ b/test/testUtils/testConstants.js
@@ -1,3 +1,6 @@
+require('dotenv').load({
+  silent: true
+});
 const UNIQUE_JOB_SUFFIX_ID = process.env.TRAVIS_JOB_ID || Math.floor(Math.random() * 999999);
 
 // create public ID string for tests

--- a/tools/scripts/test.es5.sh
+++ b/tools/scripts/test.es5.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mocha --recursive --require 'babel-register' --require 'babel-polyfill' test/
+mocha --require 'babel-register' --require 'babel-polyfill' "./test/**/*spec.js"

--- a/tools/scripts/test.es5.sh
+++ b/tools/scripts/test.es5.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-mocha --require 'babel-register' --require 'babel-polyfill' "./test/**/*spec.js"
+# Mocha 8 does not support node < 10
+# Force Mocha 6, can be removed once we drop support for Node 6
+npm install mocha@6
+mocha --require './test/setup.js' --require 'babel-register' --require 'babel-polyfill' "./test/**/*spec.js"

--- a/tools/scripts/test.es6.sh
+++ b/tools/scripts/test.es6.sh
@@ -12,9 +12,9 @@ done
 
 if [ "$COLLECT_COVERAGE" -eq "1" ]; then
   echo 'Running code coverage test on ES6 code'
-  nyc --reporter=html mocha --recursive test/
+  nyc --reporter=html mocha "./test/**/*spec.js"
   exit;
 else
   echo 'Running tests on ES6 Code'
-  mocha --recursive test/
+  mocha "./test/**/*spec.js"
 fi

--- a/tools/scripts/test.sh
+++ b/tools/scripts/test.sh
@@ -3,9 +3,15 @@ set -e;
 
 node_v=$(node --version) ;
 npm run lint
-if [[ "${node_v%%.*}" == 'v4' || "${node_v%%.*}" == 'v6' ]]
-then
+
+if [[ "${node_v%%.*}" == 'v4' || "${node_v%%.*}" == 'v6' ]]; then
   npm run test-es5
+
+elif [[ "${node_v%%.*}" == 'v8' || "${node_v%%.*}" == 'v8' ]]; then
+  # Mocha 8 does not support Node < 10,
+  # Force Mocha 6, can be removed once we drop support for Node 8
+  npm install mocha@6
+  npm run test-es6
 else
   npm run test-es6
 fi


### PR DESCRIPTION
- Move retries(3) to configuration
- Remove unneeded mocha configuration
- Change tests to run on spec.js only (and not any js file under /test)
- Remove mocha.opts (deprecated) and introduce mocharc.json
- Add a sanity check that cloudinary_url exists in setup.js