### PR TITLE
Prepare using setup.js as the main entrypoint for tests

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "recursive": true,
+  "retries": 3
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "types": "types",
   "scripts": {
     "test": "tools/scripts/test.sh",
-    "test:unit": "mocha --recursive test/unit",
+    "test:unit": "tools/scripts/test.es6.unit.sh",
     "test-with-temp-cloud": "tools/scripts/tests-with-temp-cloud.sh",
     "dtslint": "tools/scripts/ditslint.sh",
     "lint": "tools/scripts/lint.sh",

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -141,7 +141,6 @@ function findByAttr(elements, attr, value) {
 
 
 describe("api", function () {
-  this.retries(3);
   var contextKey = `test-key${UNIQUE_JOB_SUFFIX_ID}`;
   before("Verify Configuration", function () {
     let config = cloudinary.config(true);

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -24,7 +24,6 @@ const SEARCH_TAG = 'npm_advanced_search_' + UNIQUE_JOB_SUFFIX_ID;
 
 
 describe("search_api", function () {
-  this.retries(3);
   describe("unit", function () {
     it('should create empty json', function () {
       var query_hash = cloudinary.v2.search.instance().to_query();

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -85,7 +85,6 @@ sharedExamples('archive', function () {
 });
 
 describe("archive", function () {
-  this.retries(3);
   includeContext('archive');
   describe("utils", function () {
     describe('.generate_zip_download_url', function () {

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -40,7 +40,6 @@ const {
 require('jsdom-global')();
 
 describe("uploader", function () {
-  this.retries(3);
   before("Verify Configuration", function () {
     var config = cloudinary.config(true);
     if (!(config.api_key && config.api_secret)) {

--- a/test/integration/streaming_profiles_spec.js
+++ b/test/integration/streaming_profiles_spec.js
@@ -1,8 +1,8 @@
 const keys = require('lodash/keys');
 const Q = require('q');
-const cloudinary = require("../cloudinary");
-const helper = require("./spechelper");
-const TIMEOUT = require('./testUtils/testConstants').TIMEOUT;
+const cloudinary = require("../../cloudinary");
+const helper = require("../spechelper");
+const TIMEOUT = require('../testUtils/testConstants').TIMEOUT;
 const api = cloudinary.v2.api;
 
 describe('Cloudinary::Api', function () {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---require './test/setup.js'
--R spec
---ui bdd

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,9 +1,11 @@
-global.expect = require('expect.js');
-require('./testUtils/testBootstrap');
-
-
+console.log('Running');
 require('dotenv').load({
   silent: true
 });
 
+if (!process.env.CLOUDINARY_URL) {
+  throw 'Could not start tests - Cloudianry URL is undefined'
+}
 
+global.expect = require('expect.js');
+require('./testUtils/testBootstrap');

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,3 @@
-console.log('Running');
 require('dotenv').load({
   silent: true
 });

--- a/test/testUtils/testConstants.js
+++ b/test/testUtils/testConstants.js
@@ -1,3 +1,6 @@
+require('dotenv').load({
+  silent: true
+});
 const UNIQUE_JOB_SUFFIX_ID = process.env.TRAVIS_JOB_ID || Math.floor(Math.random() * 999999);
 
 // create public ID string for tests

--- a/tools/scripts/test.es6.sh
+++ b/tools/scripts/test.es6.sh
@@ -12,9 +12,19 @@ done
 
 if [ "$COLLECT_COVERAGE" -eq "1" ]; then
   echo 'Running code coverage test on ES6 code'
-  nyc --reporter=html mocha --recursive test/
+
+  # --File ensures that setup.js runs first
+  # This file should be in the config under a 'require' key
+  # However Mocha 6 does not expose before, beforeEach after etc. at that time
+  # When Removing support of Node 6 and 8 and using Mocha 8, we should move this to the mocharc.json file
+  nyc --reporter=html mocha --file "./test/setup.js" "./test/**/*spec.js"
   exit;
 else
   echo 'Running tests on ES6 Code'
-  mocha --recursive test/
+
+  # --File ensures that setup.js runs first
+  # This file should be in the config under a 'require' key
+  # However Mocha 6 does not expose before, beforeEach after etc. at that time
+  # When Removing support of Node 6 and 8 and using Mocha 8, we should move this to the mocharc.json file
+  mocha --file "./test/setup.js" "./test/**/*spec.js"
 fi

--- a/tools/scripts/test.es6.unit.sh
+++ b/tools/scripts/test.es6.unit.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-
 # --File ensures that setup.js runs first
 # This file should be in the config under a 'require' key
 # However Mocha 6 does not expose before, beforeEach after etc. at that time
 # When Removing support of Node 6 and 8 and using Mocha 8, we should move this to the mocharc.json file
-mocha --require './test/setup.js' --require 'babel-register' --require 'babel-polyfill' "./test/**/*spec.js"
+mocha --file "./test/setup.js" "./test/unit/**/*spec.js"


### PR DESCRIPTION
We'd like to use **./test/setup.js** as the main entrypoint for tests.
In the future, we'd like to add global before and after to this file (For example, a clean up all test files in a single place, instead of per suite).

Also, this file can be leveraged for setup work (For example uploading files, preparing some data etc.)
Another use could be a central point of validation (right now all our tests ensure the config exists separately, maybe we could consolidate that)