### PR TITLE
Create our custom Describe() to always reset the config in every before

### DIFF
--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -4,6 +4,7 @@ const http = require('http');
 const Q = require('q');
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
+const describe = require('../../../testUtils/suite');
 const wait = require('../../../testUtils/helpers/wait');
 const sharedExamples = helper.sharedExamples;
 const itBehavesLike = helper.itBehavesLike;
@@ -70,7 +71,7 @@ const EXPLICIT_TRANSFORMATION2 = {
 
 
 sharedExamples("a list with a cursor", function (testFunc, ...args) {
-  specify(":max_results", function () {
+  describe(":max_results", function () {
     return helper.mockPromise(function (xhr, writeSpy, requestSpy) {
       testFunc(...args, {
         max_results: 10
@@ -142,12 +143,6 @@ function findByAttr(elements, attr, value) {
 
 describe("api", function () {
   var contextKey = `test-key${UNIQUE_JOB_SUFFIX_ID}`;
-  before("Verify Configuration", function () {
-    let config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
   before(function () {
     this.timeout(TIMEOUT.LONG);
     return Q.allSettled([

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -71,7 +71,7 @@ const EXPLICIT_TRANSFORMATION2 = {
 
 
 sharedExamples("a list with a cursor", function (testFunc, ...args) {
-  describe(":max_results", function () {
+  specify(":max_results", function () {
     return helper.mockPromise(function (xhr, writeSpy, requestSpy) {
       testFunc(...args, {
         max_results: 10

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -2,7 +2,7 @@ const Q = require('q');
 const cloudinary = require('../../../../cloudinary');
 const helper = require("../../../spechelper");
 const testConstants = require('../../../testUtils/testConstants');
-
+const describe = require('../../../testUtils/suite');
 const {
   TIMEOUT,
   TAGS,
@@ -86,12 +86,6 @@ describe("search_api", function () {
   });
   describe("integration", function () {
     this.timeout(TIMEOUT.LONG);
-    before("Verify Configuration", function () {
-      var config = cloudinary.config(true);
-      if (!(config.api_key && config.api_secret)) {
-        expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-      }
-    });
     before(function () {
       return Q.allSettled([
         cloudinary.v2.uploader.upload(helper.IMAGE_FILE,

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -5,6 +5,7 @@ const execSync = require('child_process').execSync;
 const Q = require('q');
 const fs = require('fs');
 const os = require('os');
+const describe = require('../../../testUtils/suite');
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
 
@@ -37,13 +38,6 @@ const FULLY_QUALIFIED_IMAGE = "image/upload/sample";
 const FULLY_QUALIFIED_VIDEO = "video/upload/dog";
 
 sharedExamples('archive', function () {
-  before("Verify Configuration", function () {
-    var config;
-    config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
   before(function () {
     this.timeout(TIMEOUT.LONG);
     return Q.all([

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -9,6 +9,7 @@ const uniq = require('lodash/uniq');
 const ClientRequest = require('_http_client').ClientRequest;
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
+const describe = require('../../../testUtils/suite');
 
 const IMAGE_FILE = helper.IMAGE_FILE;
 const LARGE_RAW_FILE = helper.LARGE_RAW_FILE;
@@ -40,12 +41,6 @@ const {
 require('jsdom-global')();
 
 describe("uploader", function () {
-  before("Verify Configuration", function () {
-    var config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
   this.timeout(TIMEOUT.LONG);
   after(function () {
     var config = cloudinary.config(true);

--- a/test/integration/streaming_profiles_spec.js
+++ b/test/integration/streaming_profiles_spec.js
@@ -1,3 +1,4 @@
+let describe = require('../testUtils/suite');
 const keys = require('lodash/keys');
 const Q = require('q');
 const cloudinary = require("../../cloudinary");
@@ -12,12 +13,7 @@ describe('Cloudinary::Api', function () {
   test_id_1 = `${prefix}_1`;
   test_id_2 = `${prefix}_2`;
   test_id_3 = `${prefix}_3`;
-  before("Verify configuration", function () {
-    var config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
+
   after(function () {
     cloudinary.config(true);
     if (cloudinary.config().keep_test_products) {

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -252,3 +252,5 @@ exports.toISO8601DateOnly = function (timestamp) {
   const date = new Date(timestamp);
   return date.toISOString().split('T')[0];
 };
+
+

--- a/test/testUtils/suite.js
+++ b/test/testUtils/suite.js
@@ -1,0 +1,15 @@
+const cloudinary = require("../../cloudinary");
+
+function makeSuite(name, tests) {
+  describe(name, function () {
+    before("Verify configuration", function () {
+      var config = cloudinary.config(true);
+      if (!(config.api_key && config.api_secret)) {
+        expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
+      }
+    });
+    tests.apply(this);
+  });
+}
+
+module.exports = makeSuite;

--- a/test/unit/access_control_spec.js
+++ b/test/unit/access_control_spec.js
@@ -1,3 +1,4 @@
+const describe = require('../testUtils/suite');
 const isString = require('lodash/isString');
 const cloudinary = require("../../cloudinary");
 const build_upload_params = cloudinary.utils.build_upload_params;
@@ -15,12 +16,6 @@ const ACL_2 = {
 const ACL_STRING = '{"access_type":"anonymous","start":"2019-02-22 16:20:57 +0200","end":"2019-03-22 00:00 +0200"}';
 
 describe("Access Control", function () {
-  before("Verify Configuration", function () {
-    let config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
   describe("build_upload_params", function () {
     it("should accept a Hash value", function () {
       let params = build_upload_params({

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -4,6 +4,7 @@ const defaults = require('lodash/defaults');
 const cloudinary = require("../../cloudinary");
 const helper = require("../spechelper");
 const TIMEOUT = require('../testUtils/testConstants').TIMEOUT;
+const describe = require('../testUtils/suite');
 const wait = require('../testUtils/helpers/wait');
 const generateBreakpoints = require(`../../${helper.libPath}/utils/generateBreakpoints`);
 const { srcsetUrl, generateSrcsetAttribute } = require(`../../${helper.libPath}/utils/srcsetUtils`);
@@ -20,12 +21,6 @@ var cloud_name = '';
 var root_path = '';
 
 describe("utils", function () {
-  before("Verify Configuration", function () {
-    var config = cloudinary.config(true);
-    if (!(config.api_key && config.api_secret)) {
-      expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
-    }
-  });
   afterEach(function () {
     cloudinary.config(defaults({
       secure: null
@@ -823,6 +818,7 @@ describe("utils", function () {
         expect(cloudinary.utils.generate_transformation_string(option)).to.eql(expected);
       });
     });
+
     describe('Conditional Transformation', function () {
       var configBck = null;
       before(function () {
@@ -834,186 +830,185 @@ describe("utils", function () {
         });
         cloud_name = 'test123';
       });
+
       after(function () {
         cloudinary.config(configBck);
       });
-      describe('with literal condition string', function () {
-        it("should include the if parameter as the first component in the transformation string", function () {
-          var url = utils.url("sample", {
-            if: "w_lt_200",
-            crop: "fill",
-            height: 120,
-            width: 80
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
-          url = utils.url("sample", {
-            crop: "fill",
-            height: 120,
-            if: "w_lt_200",
-            width: 80
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
+
+      it("should include the if parameter as the first component in the transformation string", function () {
+        var url = utils.url("sample", {
+          if: "w_lt_200",
+          crop: "fill",
+          height: 120,
+          width: 80
         });
-        describe('conditional duration video', function () {
-          it("should include conditional transformation", function () {
-            var url = utils.url("test", {
-              resource_type: 'video',
-              if: "duration > 30",
-              width: 100
-            });
-            expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_du_gt_30,w_100/test");
-            url = utils.url("test", {
-              resource_type: 'video',
-              if: "initialDuration > 30",
-              width: 100
-            });
-            expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_idu_gt_30,w_100/test");
-            url = utils.url("test", {
-              resource_type: 'video',
-              if: "initial_duration > 30",
-              width: 100
-            });
-            expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_idu_gt_30,w_100/test");
-          });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
+        url = utils.url("sample", {
+          crop: "fill",
+          height: 120,
+          if: "w_lt_200",
+          width: 80
         });
-        it("should allow multiple conditions when chaining transformations ", function () {
-          var url = utils.url("sample", {
-            transformation: [
-              {
-                if: "w_lt_200",
-                crop: "fill",
-                height: 120,
-                width: 80
-              },
-              {
-                if: "w_gt_400",
-                crop: "fit",
-                width: 150,
-                height: 150
-              },
-              {
-                effect: "sepia"
-              }
-            ]
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_w_gt_400,c_fit,h_150,w_150/e_sepia/sample");
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
+      });
+
+      it("should include conditional transformation", function () {
+        var url = utils.url("test", {
+          resource_type: 'video',
+          if: "duration > 30",
+          width: 100
         });
-        describe("including spaces and operators", function () {
-          it("should translate operators", function () {
-            var url = utils.url("sample", {
-              if: "w < 200",
+        expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_du_gt_30,w_100/test");
+        url = utils.url("test", {
+          resource_type: 'video',
+          if: "initialDuration > 30",
+          width: 100
+        });
+        expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_idu_gt_30,w_100/test");
+        url = utils.url("test", {
+          resource_type: 'video',
+          if: "initial_duration > 30",
+          width: 100
+        });
+        expect(url).to.eql("http://res.cloudinary.com/test123/video/upload/if_idu_gt_30,w_100/test");
+      });
+
+
+      it("should allow multiple conditions when chaining transformations ", function () {
+        var url = utils.url("sample", {
+          transformation: [
+            {
+              if: "w_lt_200",
               crop: "fill",
               height: 120,
               width: 80
-            });
-            expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
-          });
+            },
+            {
+              if: "w_gt_400",
+              crop: "fit",
+              width: 150,
+              height: 150
+            },
+            {
+              effect: "sepia"
+            }
+          ]
         });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_w_gt_400,c_fit,h_150,w_150/e_sepia/sample");
       });
-      describe('with tags', () => {
-        it("should allow multiple tags condition", function () {
-          var url = utils.url("sample", {
-            transformation: [
-              {
-                if: "!tag1:tag2:tag3!_in_tags",
-                crop: "fill",
-                height: 120,
-                width: 80
-              },
-              {
-                if: "else",
-                crop: "fit",
-                width: 150,
-                height: 150
-              },
-              {
-                effect: "sepia"
-              }
-            ]
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_!tag1:tag2:tag3!_in_tags,c_fill,h_120,w_80/if_else,c_fit,h_150,w_150/e_sepia/sample");
+
+
+      it("should translate operators", function () {
+        var url = utils.url("sample", {
+          if: "w < 200",
+          crop: "fill",
+          height: 120,
+          width: 80
         });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/sample");
       });
-      describe('if end', function () {
-        it("should include the if_end as the last parameter in its component", function () {
-          var url = utils.url("sample", {
-            transformation: [
-              {
-                if: "w_lt_200"
-              },
-              {
-                crop: "fill",
-                height: 120,
-                width: 80,
-                effect: "sharpen"
-              },
-              {
-                effect: "brightness:50"
-              },
-              {
-                effect: "shadow",
-                color: "red"
-              },
-              {
-                if: "end"
-              }
-            ]
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200/c_fill,e_sharpen,h_120,w_80/e_brightness:50/co_red,e_shadow/if_end/sample");
+
+      it("should allow multiple tags condition", function () {
+        var url = utils.url("sample", {
+          transformation: [
+            {
+              if: "!tag1:tag2:tag3!_in_tags",
+              crop: "fill",
+              height: 120,
+              width: 80
+            },
+            {
+              if: "else",
+              crop: "fit",
+              width: 150,
+              height: 150
+            },
+            {
+              effect: "sepia"
+            }
+          ]
         });
-        it("should support if_else with transformation parameters", function () {
-          var url = utils.url("sample", {
-            transformation: [
-              {
-                if: "w_lt_200",
-                crop: "fill",
-                height: 120,
-                width: 80
-              },
-              {
-                if: "else",
-                crop: "fill",
-                height: 90,
-                width: 100
-              }
-            ]
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_else,c_fill,h_90,w_100/sample");
-        });
-        it("if_else should be without any transformation parameters", function () {
-          var url = utils.url("sample", {
-            transformation: [
-              {
-                if: "aspect_ratio_lt_0.7"
-              },
-              {
-                crop: "fill",
-                height: 120,
-                width: 80
-              },
-              {
-                if: "else"
-              },
-              {
-                crop: "fill",
-                height: 90,
-                width: 100
-              }
-            ]
-          });
-          expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_ar_lt_0.7/c_fill,h_120,w_80/if_else/c_fill,h_90,w_100/sample");
-        });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_!tag1:tag2:tag3!_in_tags,c_fill,h_120,w_80/if_else,c_fit,h_150,w_150/e_sepia/sample");
       });
-      describe('chaining conditions', function () {
-        it("should support and translate operators:  '=', '!=', '<', '>', '<=', '>=', '&&', '||'", function () {
-          var allOperators = 'if_' + 'w_eq_0_and' + '_h_ne_0_or' + '_ar_lt_0_and' + '_pc_gt_0_and' + '_fc_lte_0_and' + '_w_gte_0' + ',e_grayscale';
-          expect(utils.url("sample", {
-            "if": "w = 0 && height != 0 || aspectRatio < 0 and pageCount > 0 and faceCount <= 0 and width >= 0",
-            "effect": "grayscale"
-          })).to.match(new RegExp(allOperators));
+
+      it("should include the if_end as the last parameter in its component", function () {
+        var url = utils.url("sample", {
+          transformation: [
+            {
+              if: "w_lt_200"
+            },
+            {
+              crop: "fill",
+              height: 120,
+              width: 80,
+              effect: "sharpen"
+            },
+            {
+              effect: "brightness:50"
+            },
+            {
+              effect: "shadow",
+              color: "red"
+            },
+            {
+              if: "end"
+            }
+          ]
         });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200/c_fill,e_sharpen,h_120,w_80/e_brightness:50/co_red,e_shadow/if_end/sample");
+      });
+      it("should support if_else with transformation parameters", function () {
+        var url = utils.url("sample", {
+          transformation: [
+            {
+              if: "w_lt_200",
+              crop: "fill",
+              height: 120,
+              width: 80
+            },
+            {
+              if: "else",
+              crop: "fill",
+              height: 90,
+              width: 100
+            }
+          ]
+        });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_else,c_fill,h_90,w_100/sample");
+      });
+      it("if_else should be without any transformation parameters", function () {
+        var url = utils.url("sample", {
+          transformation: [
+            {
+              if: "aspect_ratio_lt_0.7"
+            },
+            {
+              crop: "fill",
+              height: 120,
+              width: 80
+            },
+            {
+              if: "else"
+            },
+            {
+              crop: "fill",
+              height: 90,
+              width: 100
+            }
+          ]
+        });
+        expect(url).to.eql("http://res.cloudinary.com/test123/image/upload/if_ar_lt_0.7/c_fill,h_120,w_80/if_else/c_fill,h_90,w_100/sample");
+      });
+
+      it("should support and translate operators:  '=', '!=', '<', '>', '<=', '>=', '&&', '||'", function () {
+        var allOperators = 'if_' + 'w_eq_0_and' + '_h_ne_0_or' + '_ar_lt_0_and' + '_pc_gt_0_and' + '_fc_lte_0_and' + '_w_gte_0' + ',e_grayscale';
+        expect(utils.url("sample", {
+          "if": "w = 0 && height != 0 || aspectRatio < 0 and pageCount > 0 and faceCount <= 0 and width >= 0",
+          "effect": "grayscale"
+        })).to.match(new RegExp(allOperators));
       });
     });
+
     describe('Context metadata to user variables', function (){
       it('should use context value as user variables', function(){
         const options = {


### PR DESCRIPTION
In this PR we'd like to address the many times we had to reset our configuration in the tests.
It has gotten to a point where it's not clear what's the config in every describe() block due to increasing config mutations.

Over time, this forced us to reset the config even without knowing if it's needed, for a 'just in case' scenario.

This PR comes to streamline this process, we'll force a reset of the config before every describe() is called to ensure that the state of the config is known at any point.

- Create a makeSuite() function that creates wraps the describe() function
- Reset config per describe() by inserting a before() block
- Refactor tests that abused nested describe for no reason, and failed after this change.