### PR TITLE
Refactor a single file to show case how the change looks like

### DIFF
--- a/test/testUtils/reusableTests/image/imageAttributesWithClientHInts.js
+++ b/test/testUtils/reusableTests/image/imageAttributesWithClientHInts.js
@@ -1,0 +1,28 @@
+const registerReusableTest = require('../reusableTests').registerReusableTest;
+const cloudinary = require('../../../../cloudinary');
+
+const UPLOAD_PATH = "http://res.cloudinary.com/test123/image/upload";
+const srcRegExp = function (name, path) {
+  return RegExp(`${name}=["']${UPLOAD_PATH}/${path}["']`.replace("/", "\/"));
+};
+
+registerReusableTest("Expects correct image tag attributes when client hints are used", function(options) {
+  it("should not use data-src or set responsive class", function() {
+    var tag = cloudinary.image('sample.jpg', options);
+    expect(tag).to.match(/<img.*>/);
+    expect(tag).not.to.match(/<.*class.*>/);
+    expect(tag).not.to.match(/\bdata-src\b/);
+    expect(tag).to.match(srcRegExp("src", "c_scale,dpr_auto,w_auto/sample.jpg"));
+  });
+  it("should override responsive", function () {
+    var tag;
+    cloudinary.config({
+      responsive: true
+    });
+    tag = cloudinary.image('sample.jpg', options);
+    expect(tag).to.match(/<img.*>/);
+    expect(tag).not.to.match(/<.*class.*>/);
+    expect(tag).not.to.match(/\bdata-src\b/);
+    expect(tag).to.match(srcRegExp("src", "c_scale,dpr_auto,w_auto/sample.jpg"));
+  });
+});

--- a/test/testUtils/reusableTests/reusableTests.js
+++ b/test/testUtils/reusableTests/reusableTests.js
@@ -1,0 +1,16 @@
+const registeredTests = {};
+
+function registerReusableTest(name, testFn) {
+  registeredTests[name] = testFn;
+}
+
+function callReusableTest(name, testArgs) {
+  registeredTests[name](testArgs);
+}
+
+module.exports = {
+  callReusableTest
+};
+
+
+module.exports = {registerReusableTest, callReusableTest};

--- a/test/testUtils/testBootstrap.js
+++ b/test/testUtils/testBootstrap.js
@@ -5,3 +5,8 @@ const path = require('path');
 glob.sync(`${__dirname}/assertions/*.js`).forEach(function (file) {
   require(path.resolve(file));
 });
+
+// Import all reusable tests so they can be used with a name
+glob.sync(`${__dirname}/reusableTests/**/*.js`).forEach(function (file) {
+  require(path.resolve(file));
+});

--- a/test/unit/tags/image_spec.js
+++ b/test/unit/tags/image_spec.js
@@ -1,5 +1,5 @@
 const cloudinary = require('../../../cloudinary');
-const { setupCache, sharedExamples, includeContext } = require("../../spechelper");
+const { setupCache } = require("../../spechelper");
 
 const { extend, isEmpty } = cloudinary.utils;
 const BREAKPOINTS = [5, 3, 7, 5];
@@ -10,6 +10,9 @@ const srcRegExp = function (name, path) {
 };
 
 const createTestConfig = require('../../testUtils/createTestConfig');
+const callReusableTest = require('../../testUtils/reusableTests/reusableTests').callReusableTest;
+
+
 
 describe('image helper', function () {
   var commonTrans, commonTransformationStr, customAttributes;
@@ -109,29 +112,10 @@ describe('image helper', function () {
       alt: "asdfg\"'asdf"
     })).to.eql(`<img src='${UPLOAD_PATH}/sample.jpg' alt='asdfg&#34;&#39;asdf'/>`);
   });
-  sharedExamples("client_hints", function(options) {
-    it("should not use data-src or set responsive class", function() {
-      var tag = cloudinary.image('sample.jpg', options);
-      expect(tag).to.match(/<img.*>/);
-      expect(tag).not.to.match(/<.*class.*>/);
-      expect(tag).not.to.match(/\bdata-src\b/);
-      expect(tag).to.match(srcRegExp("src", "c_scale,dpr_auto,w_auto/sample.jpg"));
-    });
-    it("should override responsive", function () {
-      var tag;
-      cloudinary.config({
-        responsive: true
-      });
-      tag = cloudinary.image('sample.jpg', options);
-      expect(tag).to.match(/<img.*>/);
-      expect(tag).not.to.match(/<.*class.*>/);
-      expect(tag).not.to.match(/\bdata-src\b/);
-      expect(tag).to.match(srcRegExp("src", "c_scale,dpr_auto,w_auto/sample.jpg"));
-    });
-  });
+
   describe(":client_hints", function () {
     describe("as option", function () {
-      includeContext("client_hints", {
+      callReusableTest("Expects correct image tag attributes when client hints are used", {
         dpr: "auto",
         cloud_name: "test123",
         width: "auto",
@@ -143,7 +127,7 @@ describe('image helper', function () {
       beforeEach(function () {
         cloudinary.config().client_hints = true;
       });
-      includeContext("client_hints", {
+      callReusableTest("Expects correct image tag attributes when client hints are used", {
         dpr: "auto",
         cloud_name: "test123",
         width: "auto",


### PR DESCRIPTION
This PR tries to add more semantics into our test code base.

I propose we replace sharedExamples and includeContext (Which look like aliases) with "reusableTests" (Which is the right meaning).

We'll include an API to add reusable tests, and move them into a separate place in our file system to make organize our codebase. 

This is a POC, and not a complete solution - just showing how it will look like in a single file.
The full refactor should change all relevant files.