### PR TITLE
Fix and improve docstring for download_folder()

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1187,8 +1187,8 @@ function download_zip_url() {
 }
 
 /**
- * Creates and returns a URL that when invokes creates an archive of a folder
- * @param {string} folder_path Full path from the root of the folder to download
+ * Creates and returns a URL that when invoked creates an archive of a folder
+ * @param {string} folder_path Full path (from the root) of the folder to download
  * @param {object} options Additional options
  * @returns {string} Url for downloading an archive of a folder
  */

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1187,7 +1187,10 @@ function download_zip_url() {
 }
 
 /**
- * Creates and downloads a URL that when invokes creates an archive of a folder
+ * Creates and returns a URL that when invokes creates an archive of a folder
+ * @param {string} folder_path Full path from the root of the folder to download
+ * @param {object} options Additional options
+ * @returns {string} Url for downloading an archive of a folder
  */
 function download_folder(folder_path) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1090,7 +1090,10 @@ function download_zip_url(options = {}) {
 }
 
 /**
- * Creates and downloads a URL that when invokes creates an archive of a folder
+ * Creates and returns a URL that when invokes creates an archive of a folder
+ * @param {string} folder_path Full path from the root of the folder to download
+ * @param {object} options Additional options
+ * @returns {string} Url for downloading an archive of a folder
  */
 function download_folder(folder_path, options = {}) {
   options.resource_type = options.resource_type || "all";

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1090,8 +1090,8 @@ function download_zip_url(options = {}) {
 }
 
 /**
- * Creates and returns a URL that when invokes creates an archive of a folder
- * @param {string} folder_path Full path from the root of the folder to download
+ * Creates and returns a URL that when invoked creates an archive of a folder
+ * @param {string} folder_path Full path (from the root) of the folder to download
  * @param {object} options Additional options
  * @returns {string} Url for downloading an archive of a folder
  */


### PR DESCRIPTION
* Changed the method description from: `Creates and downloads a URL…` to `Creates and returns a URL…`.
* Minor grammar fix.
* Added more details about the method to the docstring
