### PR TITLE
Fix docstring for pending parameter of the users method

### DIFF
--- a/lib-es5/provisioning/account.js
+++ b/lib-es5/provisioning/account.js
@@ -138,7 +138,7 @@ function user(user_id) {
 
 /**
  * @desc Lists users in the account.
- * @param [pending] {boolean} - Whether to only return pending users. Default: false (all users)
+ * @param [pending] {boolean} - Limit results to pending users (true), users that are not pending (false), or all users (undefined, the default)
  * @param [user_ids] {string[]} - A list of up to 100 user IDs. When provided, other parameters are ignored.
  * @param [prefix] {string} - Returns users where the name or email address begins with the specified case-insensitive
  *                            string.

--- a/lib/provisioning/account.js
+++ b/lib/provisioning/account.js
@@ -117,7 +117,7 @@ function user(user_id, options = {}, callback) {
 
 /**
  * @desc Lists users in the account.
- * @param [pending] {boolean} - Whether to only return pending users. Default: false (all users)
+ * @param [pending] {boolean} - Limit results to pending users (true), users that are not pending (false), or all users (undefined, the default)
  * @param [user_ids] {string[]} - A list of up to 100 user IDs. When provided, other parameters are ignored.
  * @param [prefix] {string} - Returns users where the name or email address begins with the specified case-insensitive
  *                            string.


### PR DESCRIPTION
The docstring explaining the use of the `pending` parameter of the `users()` method in the Account Provisioning API is wrong.

The default is not false, it is undefined which has a different meaning than false in the API server.

The Account Provisioning API responds to the pending parameter like this:

* `pending = true` returns only the users that are pending
* `pending = false` returns only the users that are not pending
* `pending = undefined` returns all users (i.e., don't limit based on pending status)

I made the comment extra verbose as this has been the source of much confusion across all SDKs.

Note: testing for this was added in #417.