### PR TITLE
Force dtslint version 0.9.1 to support node6

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-register": "^6.26.0",
     "babel-runtime": "^6.26.0",
     "dotenv": "4.x",
-    "dtslint": "^0.9.1",
+    "dtslint": "0.9.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",


### PR DESCRIPTION
### Brief Summary of Changes
dtslint had a breaking update that resulted in errors for node6.
This PR forces the version of dtslint to be `0.9.1` instead of `^0.9.1`

#### What does this PR address?
- [ ] Github issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

