### PR TITLE
Skip dtslint in older node versions

### DIFF
--- a/tools/scripts/test.sh
+++ b/tools/scripts/test.sh
@@ -8,6 +8,6 @@ then
   npm run test-es5
 else
   npm run test-es6
-fi
   npm run dtslint
+fi
 


### PR DESCRIPTION
### Brief Summary of Changes
Skips DTSlint checks in older node version (no longer supported, throws exceptions)

#### What does this PR address?
- [ ] Github issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No
