### PR TITLE
Fix the build docs command

### DIFF
--- a/lib/utils/encoding/encodeDoubleArray.js
+++ b/lib/utils/encoding/encodeDoubleArray.js
@@ -3,7 +3,7 @@ const toArray = require('../parsing/toArray');
 
 /**
  * Serialize an array of arrays into a string
- * @param {[]|[[]]} array - An array of arrays.
+ * @param {string[] | Array.<Array.<string>>} array - An array of arrays.
  *                          If the first element is not an array the argument is wrapped in an array.
  * @returns {string} A string representation of the arrays.
  */

--- a/lib/utils/parsing/toArray.js
+++ b/lib/utils/parsing/toArray.js
@@ -3,7 +3,7 @@ const isArray = require('lodash/isArray');
 /**
  * @desc Turns arguments that aren't arrays into arrays
  * @param arg
- * @returns {*[]|*}
+ * @returns { any | any[] }
  */
 function toArray(arg) {
   switch (true) {

--- a/tools/scripts/lint.sh
+++ b/tools/scripts/lint.sh
@@ -6,6 +6,6 @@ if [[ "${node_v%%.*}" == 'v4' || "${node_v%%.*}" == 'v6' ]]
 then
   echo 'Old node version - Skipping eslint'
 else
-  eslint .
+  eslint ./test ./lib
 fi
 


### PR DESCRIPTION
### Brief Summary of Changes
This PR fixes the `npm run docs` command, also adjusts the linter to only lint `lib` and `test` and not any thing else (like lib-es5 or docs)


#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

