### PR TITLE
Encode all URI components when building a URL in base_api_url()

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -969,7 +969,11 @@ function base_api_url() {
 
   var cloudinary = ensureOption(options, "upload_prefix", UPLOAD_PREFIX);
   var cloud_name = ensureOption(options, "cloud_name");
-  return [cloudinary, "v1_1", cloud_name].concat(path).join("/");
+  var encode_path = function encode_path(unencoded_path) {
+    return encodeURIComponent(unencoded_path).replace("'", '%27');
+  };
+  var encoded_path = Array.isArray(path) ? path.map(encode_path) : encode_path(path);
+  return [cloudinary, "v1_1", cloud_name].concat(encoded_path).join("/");
 }
 
 function api_url() {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -908,7 +908,9 @@ function unsigned_url_prefix(
 function base_api_url(path= [], options = {}) {
   let cloudinary = ensureOption(options, "upload_prefix", UPLOAD_PREFIX);
   let cloud_name = ensureOption(options, "cloud_name");
-  return [cloudinary, "v1_1", cloud_name].concat(path).join("/");
+  let encode_path = unencoded_path => encodeURIComponent(unencoded_path).replace("'", '%27');
+  let encoded_path = Array.isArray(path) ? path.map(encode_path) : encode_path(path);
+  return [cloudinary, "v1_1", cloud_name].concat(encoded_path).join("/");
 }
 
 function api_url(action = 'upload', options = {}) {

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -437,6 +437,11 @@ describe("utils", function () {
         type: "youtube"
       }, `http://res.cloudinary.com/${cloud_name}/image/youtube/http://www.youtube.com/watch%3Fv%3Dd9NF2edxy-M`, {});
     });
+    it('should escape api urls', function () {
+      const folderName = "sub^folder's test";
+      const url = utils.base_api_url(['folders', folderName]);
+      expect(url).to.match(/folders\/sub%5Efolder%27s%20test$/);
+    });
   });
   describe('transformation parameters', function () {
     describe("gravity", function () {


### PR DESCRIPTION
### Brief Summary of Changes
Encode special characters in the path of API calls.

#### What Does This PR Address?
- [x] Bug fix

#### Are Tests Included?
- [x] Yes

#### Reviewer, Please Note:

We have based this on the implementation in https://github.com/cloudinary/cloudinary_gem/pull/361

We have made one modification to the test to verify that apostrophes are also encoded. We have decided to do this because some implementations might not encode apostrophes as they are ignored by `encodeURIComponent` even though they are not legal in the path.