### PR TITLE
Fix type of generate_auth_token options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -535,6 +535,7 @@ declare module 'cloudinary' {
         start_time?: number;
         duration?: number;
         expiration?: number;
+        url?: string;
     }
 
     type TransformationOptions =

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -528,6 +528,15 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
+    export interface AuthTokenApiOptions {
+        key: string;
+        acl: string;
+        ip?: string;
+        start_time?: number;
+        duration?: number;
+        expiration?: number;
+    }
+
     type TransformationOptions =
         string
         | string[]
@@ -716,7 +725,7 @@ declare module 'cloudinary' {
 
             function download_zip_url(options?: ArchiveApiOptions | ConfigAndUrlOptions): string;
 
-            function generate_auth_token(options?: ConfigOptions): string;
+            function generate_auth_token(options?: AuthTokenApiOptions): string;
 
             function webhook_signature(data?: string, timestamp?: number, options?: ConfigOptions): string;
         }


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

This fixes that the options passed to `generate_auth_token` causes type error in TypeScript.

Although `genearte_auth_token` should receive options include key, acl, ip, etc. , the type of that options points to `ConfigOptions` type. It causes type error on actual application codes.

So I have added new type `AuthTokenApiOptions` and changed  `genearte_auth_token` to receive this newly added type.


#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

- There might have to be added tests in `types/cloudinary_ts_spec.ts`, but I am not sure how I add tests in it and how to run these tests
- Though `auth` sub-option of `ConfigOptions` also receive token options, I don't change it at all because that option is typed as `object` and it does not cause type mismatch error at the time
