### PR TITLE
Set the provisioning API config as optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -347,8 +347,8 @@ declare module 'cloudinary' {
         use_root_path?: boolean;
         auth_token?: object;
         account_id?: string;
-        provisioning_api_key: string;
-        provisioning_api_secret: string;
+        provisioning_api_key?: string;
+        provisioning_api_secret?: string;
 
         [futureKey: string]: any;
     }


### PR DESCRIPTION
### Brief Summary of Changes
Set the provisioning API config as optional

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [X] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No

#### Reviewer, Please Note:
The config options were mistakenly added as mandatory, they should've been optional.