### PR TITLE
Add missing public_ids[] param for resources function

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -22,17 +22,21 @@ exports.resource_types = function resource_types(callback, options = {}) {
 };
 
 exports.resources = function resources(callback, options = {}) {
-  let resource_type, type, uri;
+  let params, resource_type, type, uri;
   resource_type = options.resource_type || "image";
   type = options.type;
   uri = ["resources", resource_type];
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at");
   if (type != null) {
     uri.push(type);
   }
   if ((options.start_at != null) && Object.prototype.toString.call(options.start_at) === '[object Date]') {
     options.start_at = options.start_at.toUTCString();
   }
-  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at"), callback, options);
+  if (options.public_ids != null) {
+    params["public_ids[]"] = options.public_ids;
+  }
+  return call_api("get", uri, params, callback, options);
 };
 
 exports.resources_by_tag = function resources_by_tag(tag, callback, options = {}) {


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
There is a public_ids option in the Admin API docs that is missing functionality in the resources function. Added public_ids to the param for the function.

Section where this is found:
https://cloudinary.com/documentation/admin_api#get_resources

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No
