### PR TITLE
Remove unused parameter from archive_params

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1397,8 +1397,7 @@ function archive_params() {
     timestamp: options.timestamp || exports.timestamp(),
     transformations: utils.build_eager(options.transformations),
     type: options.type,
-    use_original_filename: exports.as_safe_bool(options.use_original_filename),
-    folder_path: options.folder_path
+    use_original_filename: exports.as_safe_bool(options.use_original_filename)
   };
 }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1284,8 +1284,7 @@ function archive_params(options = {}) {
     timestamp: options.timestamp || exports.timestamp(),
     transformations: utils.build_eager(options.transformations),
     type: options.type,
-    use_original_filename: exports.as_safe_bool(options.use_original_filename),
-    folder_path: options.folder_path
+    use_original_filename: exports.as_safe_bool(options.use_original_filename)
   };
 }
 


### PR DESCRIPTION
### Brief Summary of Changes

The function `archive_params()` includes `folder_path` as one of the params used to create a signature. That param does not exist in the API and is never actually passed to this function.

A param with that name is passed to the method `download_folder()` and then placed into the prefixes param. It never actually passes to the API.

#### What Does This PR Address?
- [x] Bug fix

#### Are Tests Included?
- [ ] Yes
- [x] No
