### PR TITLE
Update docstring for `normalize_expression`

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -122,9 +122,11 @@ function textStyle(layer) {
 }
 
 /**
- * Normalize an offset value
- * @param {String} expression a decimal value which may have a 'p' or '%' postfix. E.g. '35%', '0.4p'
- * @return {Object|String} a normalized String of the input value if possible otherwise the value itself
+ * Normalize an expression string, replace "nice names" with their coded values and spaces with "_"
+ * e.g. `width > 0` => `w_lt_0`
+ *
+ * @param {String} expression An expression to be normalized
+ * @return {Object|String} A normalized String of the input value if possible otherwise the value itself
  */
 function normalize_expression(expression) {
   if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {


### PR DESCRIPTION
The docstring describing `normalize_expression` is outdated and no longer properly described what it does. The docstring was updated with the description of this function from the .net SDK.

