### PR TITLE
secure_distribution has wrong type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -334,7 +334,7 @@ declare module 'cloudinary' {
         api_key?: string;
         api_secret?: string;
         private_cdn?: boolean;
-        secure_distribution?: boolean;
+        secure_distribution?: string;
         force_version?: boolean;
         ssl_detected?: boolean;
         secure?: boolean;


### PR DESCRIPTION
If I am following https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters correctly the type should be string. But it seems that a boolean is acceptable. Changing to string to see if someone can take a look if this is accurate. I should be able to place my cname in here.

### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
