### PR TITLE
Add `accessibility_analysis` parameter support

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -111,7 +111,7 @@ exports.resource = function resource(public_id, callback) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results", "versions"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback) {

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -330,7 +330,8 @@ function build_upload_params(options) {
     unique_filename: utils.as_safe_bool(options.unique_filename),
     upload_preset: options.upload_preset,
     use_filename: utils.as_safe_bool(options.use_filename),
-    quality_override: options.quality_override
+    quality_override: options.quality_override,
+    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis)
   };
   return utils.updateable_resource_params(options, params);
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -76,7 +76,7 @@ exports.resource = function resource(public_id, callback, options = {}) {
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type, public_id];
-  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results", "versions"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis"), callback, options);
 };
 
 exports.restore = function restore(public_ids, callback, options = {}) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -311,7 +311,8 @@ function build_upload_params(options) {
     unique_filename: utils.as_safe_bool(options.unique_filename),
     upload_preset: options.upload_preset,
     use_filename: utils.as_safe_bool(options.use_filename),
-    quality_override: options.quality_override
+    quality_override: options.quality_override,
+    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis)
   };
   return utils.updateable_resource_params(options, params);
 }

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -284,6 +284,14 @@ describe("api", function () {
         });
       });
     });
+    it("should send `accessibility_analysis` param to the server", function () {
+      return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+        cloudinary.v2.api.resource(PUBLIC_ID, { accessibility_analysis: true });
+        return sinon.assert.calledWith(requestSpy, sinon.match({
+          query: sinon.match(helper.apiParamMatcher("accessibility_analysis", "true"))
+        }));
+      });
+    });
   });
   describe("backup resource", function () {
     this.timeout(TIMEOUT.MEDIUM);

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -892,6 +892,12 @@ describe("uploader", function () {
       sinon.assert.calledWith(mocked.write, sinon.match(helper.uploadParamMatcher("async", 1)));
     });
   });
+  it("should pass `accessibility_analysis` option to the server", function () {
+    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+      cloudinary.v2.uploader.upload(IMAGE_FILE, { accessibility_analysis: true });
+      return sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("accessibility_analysis", 1)));
+    });
+  });
   describe("explicit", function () {
     var spy, xhr;
     spy = void 0;
@@ -933,6 +939,10 @@ describe("uploader", function () {
         tags: [TEST_TAG]
       });
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('raw_convert', 'google_speech')));
+    });
+    it("should pass `accessibility_analysis` to server", function () {
+      cloudinary.v2.uploader.explicit("cloudinary", { accessibility_analysis: true });
+      sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('accessibility_analysis', 1)));
     });
   });
   it("should create an image upload tag with required properties", function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -476,6 +476,7 @@ declare module 'cloudinary' {
         coordinates?: boolean;
         phash?: boolean;
         cinemagraph_analysis?: boolean;
+        accessibility_analysis?: boolean;
 
         [futureKey: string]: any;
     }


### PR DESCRIPTION
### Brief Summary of Changes

Add `accessibility_analysis` parameter to `upload`, `explicit`, and `resource` methods

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No
