### PR TITLE
Add support for date parameter in usage API

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -24,7 +24,13 @@ exports.ping = function ping(callback) {
 exports.usage = function usage(callback) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
-  return call_api("get", ["usage"], {}, callback, options);
+  var uri = ["usage"];
+
+  if (options.date) {
+    uri.push(options.date);
+  }
+
+  return call_api("get", uri, {}, callback, options);
 };
 
 exports.resource_types = function resource_types(callback) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,7 +14,13 @@ exports.ping = function ping(callback, options = {}) {
 };
 
 exports.usage = function usage(callback, options = {}) {
-  return call_api("get", ["usage"], {}, callback, options);
+  const uri = ["usage"];
+
+  if (options.date) {
+    uri.push(options.date);
+  }
+
+  return call_api("get", uri, {}, callback, options);
 };
 
 exports.resource_types = function resource_types(callback, options = {}) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.26.0",
     "babel-runtime": "^6.26.0",
+    "date-fns": "^2.16.1",
     "dotenv": "4.x",
     "dtslint": "^0.9.1",
     "eslint": "^6.8.0",

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -1,4 +1,6 @@
 const sinon = require('sinon');
+const formatDate = require("date-fns").format;
+const subDate = require("date-fns").sub;
 const ClientRequest = require('_http_client').ClientRequest;
 const Q = require('q');
 const cloudinary = require("../../../../cloudinary");
@@ -696,7 +698,20 @@ describe("api", function () {
   it("should support the usage API call", function () {
     this.timeout(TIMEOUT.MEDIUM);
     return cloudinary.v2.api.usage()
-      .then(usage => expect(usage.last_update).not.to.eql(null));
+      .then(usage => {
+        expect(usage).to.be.an("object");
+        expect(usage).to.have.keys("plan", "last_updated", "transformations", "objects", "bandwidth", "storage", "requests", "resources", "derived_resources", "media_limits");
+      });
+  });
+  it("should return usage values for a specific date", function () {
+    const yesterday = formatDate(subDate(new Date(), { days: 1 }), "dd-MM-yyyy");
+    return cloudinary.v2.api.usage({ date: yesterday })
+      .then(usage => {
+        expect(usage).to.be.an("object");
+        expect(usage).to.have.keys("plan", "last_updated", "transformations", "objects", "bandwidth", "storage", "requests", "resources", "derived_resources", "media_limits");
+        expect(usage.bandwidth).to.be.an("object");
+        expect(usage.bandwidth).to.not.have.keys("limit", "used_percent");
+      });
   });
   describe("delete_all_resources", function () {
     callReusableTest("accepts next_cursor", cloudinary.v2.api.delete_all_resources);


### PR DESCRIPTION
### Brief Summary of Changes

Usage API can now receive a `date` as a parameter.

```javascript
cloudinary.v2.api.usage({ date: '31-12-2020' })
```


#### What Does This PR Address?
- [x] New feature

#### Are Tests Included?
- [x] Yes

#### Reviewer, Please Note:

A dev dependency was added to ease date manipulation
