### PR TITLE
Change test for `eval` upload parameter

### DIFF
--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -1136,18 +1136,17 @@ describe("uploader", function () {
   });
 
   it('should add the eval parameter to an uploaded asset', async () => {
-    const testEvalTagsResult = ['a', 'b'];
     const result = await UPLOADER_V2.upload(IMAGE_FILE, {
       tags: [TEST_TAG],
       eval: TEST_EVAL_STR
     });
 
     expect(result).not.to.be.empty();
-    expect(result.tags).to.be.an("array");
-    expect(result.tags).to.eql(testEvalTagsResult);
     expect(result.context).to.be.an("object");
     expect(result.context.custom).to.be.an("object");
     expect(result.context.custom.width).to.eql(TEST_IMG_WIDTH);
+    expect(result.quality_analysis).to.be.an("object");
+    expect(result.quality_analysis.focus).to.be.an("number");
   });
 
   describe("sign requests", function () {

--- a/test/testUtils/testConstants.js
+++ b/test/testUtils/testConstants.js
@@ -16,7 +16,7 @@ const UNIQUE_TEST_FOLDER = `${TEST_TAG}_${UNIQUE_JOB_SUFFIX_ID}_folder`;
 const TEST_IMG_WIDTH = 241;
 const TEST_CLOUD_NAME = process.env.CLOUDINARY_URL.split('@')[1];
 
-const TEST_EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" }; ' +
+const TEST_EVAL_STR = 'if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true }; ' +
     'upload_options["context"] = "width=" + resource_info["width"]';
 module.exports = {
   TEST_TAG_PREFIX,


### PR DESCRIPTION
### Brief Summary of Changes

The tests for eval in all the different SDKs had a bug that caused it to leave leftover images that aren't deleted during test teardown. This fixes it by not overwriting the uploaded image's tags.

#### What Does This PR Address?
- [x] Bug fix

#### Are Tests Included?
- [x] Yes

