### PR TITLE
Add validation to genreate_auth_token to enforce url or acl

### DIFF
--- a/lib-es5/auth_token.js
+++ b/lib-es5/auth_token.js
@@ -74,5 +74,10 @@ module.exports = function (options) {
   }
   var auth = digest(toSign.join(tokenSeparator), options.key);
   tokenParts.push(`hmac=${auth}`);
+
+  if (!options.url && !options.acl) {
+    throw 'authToken must contain either an acl or a url property';
+  }
+
   return `${tokenName}=${tokenParts.join(tokenSeparator)}`;
 };

--- a/lib/auth_token.js
+++ b/lib/auth_token.js
@@ -72,5 +72,10 @@ module.exports = function (options) {
   }
   let auth = digest(toSign.join(tokenSeparator), options.key);
   tokenParts.push(`hmac=${auth}`);
+
+  if (!options.url && !options.acl) {
+    throw 'authToken must contain either an acl or a url property'
+  }
+
   return `${tokenName}=${tokenParts.join(tokenSeparator)}`;
 };

--- a/test/unit/authToken/authTokenUtils_spec.js
+++ b/test/unit/authToken/authTokenUtils_spec.js
@@ -41,4 +41,29 @@ describe("AuthToken tests using utils.generate_auth_token", function () {
     const token_with_url = utils.generate_auth_token(token_options);
     expect(token).to.eql(token_with_url)
   });
+
+  it("Should throw if generate_auth_token is missing acl or url", function () {
+    expect(() => {
+      utils.generate_auth_token({
+        start_time: 1111111111,
+        duration: 300
+      });
+    }).to.throwError();
+
+    expect(() => {
+      utils.generate_auth_token({
+        start_time: 1111111111,
+        duration: 300,
+        acl: `/*/t_foobar`
+      });
+    }).not.to.throwError();
+
+    expect(() => {
+      utils.generate_auth_token({
+        start_time: 1111111111,
+        duration: 300,
+        url: "http://res.cloudinary.com/test123/image/upload/v1486020273/sample.jpg"
+      });
+    }).not.to.throwError();
+  });
 });


### PR DESCRIPTION
### Brief Summary of Changes
Add validation to genreate_auth_token to enforce url or acl

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [X] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No
