### PR TITLE
added sort by metadata field

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -690,3 +690,21 @@ exports.restore_metadata_field_datasource = function restore_metadata_field_data
   var params = { external_ids: entries_external_id };
   return call_api("post", ["metadata_fields", field_external_id, "datasource_restore"], params, callback, options);
 };
+
+/**
+ * Sorts metadata field datasource. Currently supports only value
+ * @param {String}   field_external_id    The ID of the metadata field
+ * @param {String}   sort_by              Criteria for the sort. Currently supports only value
+ * @param {String}   direction            Optional (gets either asc or desc)
+ * @param {Function} callback             Callback function
+ * @param {Object}   options              Configuration options
+ *
+ * @return {Object}
+ */
+exports.sort_metadata_field_datasource = function sort_metadata_field_datasource(field_external_id, sort_by, direction, callback) {
+  var options = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+
+  options.content_type = "json";
+  var params = { sort_by: sort_by, direction: direction };
+  return call_api("post", ["metadata_fields", field_external_id, "datasource", "sort"], params, callback, options);
+};

--- a/lib-es5/v2/api.js
+++ b/lib-es5/v2/api.js
@@ -60,5 +60,6 @@ v1_adapters(exports, api, {
   update_metadata_field: 2,
   update_metadata_field_datasource: 2,
   delete_datasource_entries: 2,
-  restore_metadata_field_datasource: 2
+  restore_metadata_field_datasource: 2,
+  sort_metadata_field_datasource: 3
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -551,3 +551,19 @@ exports.restore_metadata_field_datasource = function restore_metadata_field_data
   const params = { external_ids: entries_external_id };
   return call_api("post", ["metadata_fields", field_external_id, "datasource_restore"], params, callback, options);
 };
+
+/**
+ * Sorts metadata field datasource. Currently supports only value
+ * @param {String}   field_external_id    The ID of the metadata field
+ * @param {String}   sort_by              Criteria for the sort. Currently supports only value
+ * @param {String}   direction            Optional (gets either asc or desc)
+ * @param {Function} callback             Callback function
+ * @param {Object}   options              Configuration options
+ *
+ * @return {Object}
+ */
+exports.sort_metadata_field_datasource = function sort_metadata_field_datasource(field_external_id, sort_by, direction, callback, options = {}) {
+  options.content_type = "json";
+  const params = { sort_by: sort_by, direction: direction};
+  return call_api("post", ["metadata_fields", field_external_id, "datasource", "sort"], params, callback, options);
+};

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -58,5 +58,6 @@ v1_adapters(exports, api, {
   update_metadata_field: 2,
   update_metadata_field_datasource: 2,
   delete_datasource_entries: 2,
-  restore_metadata_field_datasource: 2
+  restore_metadata_field_datasource: 2,
+  sort_metadata_field_datasource: 3
 });

--- a/test/integration/api/admin/structured_metadata_spec.js
+++ b/test/integration/api/admin/structured_metadata_spec.js
@@ -401,6 +401,28 @@ describe("structured metadata api", function () {
     });
   });
 
+  describe("sort_metadata_field_datasource", function () {
+    it("should sort by asc in a metadata field datasource", function () {
+      // datasource is set with values in the order v2, v3, v4
+      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_2, 'value', 'asc')
+        .then((result) => {
+          expect(result).to.beADatasource();
+          // ascending order means v2 is the first value
+          expect(result.values[0].value).to.eql('v2');
+        })
+    });
+
+    it("should sort by desc in a metadata field datasource", function () {
+      // datasource is set with values in the order v2, v3, v4
+      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_2, 'value', 'desc')
+        .then((result) => {
+          expect(result).to.beADatasource();
+          // descending order means v4 is the first value
+          expect(result.values[0].value).to.eql('v4');
+        })
+    });
+  });
+
   describe("restore_metadata_field_datasource", function () {
     it("should restore a deleted entry in a metadata field datasource", function () {
       return api.delete_datasource_entries(EXTERNAL_ID_SET_3, [DATASOURCE_ENTRY_EXTERNAL_ID])

--- a/test/integration/api/admin/structured_metadata_spec.js
+++ b/test/integration/api/admin/structured_metadata_spec.js
@@ -404,7 +404,7 @@ describe("structured metadata api", function () {
   describe("sort_metadata_field_datasource", function () {
     it("should sort by asc in a metadata field datasource", function () {
       // datasource is set with values in the order v2, v3, v4
-      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_2, 'value', 'asc')
+      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_3, 'value', 'asc')
         .then((result) => {
           expect(result).to.beADatasource();
           // ascending order means v2 is the first value
@@ -414,7 +414,7 @@ describe("structured metadata api", function () {
 
     it("should sort by desc in a metadata field datasource", function () {
       // datasource is set with values in the order v2, v3, v4
-      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_2, 'value', 'desc')
+      return api.sort_metadata_field_datasource(EXTERNAL_ID_SET_3, 'value', 'desc')
         .then((result) => {
           expect(result).to.beADatasource();
           // descending order means v4 is the first value


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Add a new method in Admin API - ‘sort_metadata_field_datasource’.

This method gets two parameters:
sort_by - string - required (currently supports only value in the BE) - criteria for the sort.
direction - string - optional (gets either asc (default value in the BE) or desc)

SNI-4242
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No
