### PR TITLE
Fix config backup in sign requests test

### DIFF
--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -10,6 +10,7 @@ const ClientRequest = require('_http_client').ClientRequest;
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
 const describe = require('../../../testUtils/suite');
+const cloneDeep = require('lodash/cloneDeep');
 
 const IMAGE_FILE = helper.IMAGE_FILE;
 const LARGE_RAW_FILE = helper.LARGE_RAW_FILE;
@@ -1173,7 +1174,7 @@ describe("uploader", function () {
     writeSpy = void 0;
     beforeEach(function () {
       writeSpy = sinon.spy(ClientRequest.prototype, 'write');
-      configBck2 = cloudinary.config();
+      configBck2 = cloneDeep(cloudinary.config());
       cloudinary.config({
         api_key: "1234",
         api_secret: ""


### PR DESCRIPTION
### Brief Summary of Changes

The method used to backup the configuration before the test didn't work.

It made `configBck2` into a **reference** to the config so when config was changed the "backup" was also changed.

#### What Does This PR Address?
- [x] Bug fix

#### Are Tests Included?
- [x] Yes
- [ ] No

