### PR TITLE
Fix/unhandled promise rejection call api

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -471,6 +471,8 @@ function call_api(action, callback, options, get_params) {
     callback = function callback() {};
   }
 
+  var USE_PROMISES = !options.disable_promises;
+
   var deferred = Q.defer();
   if (options == null) {
     options = {};
@@ -494,7 +496,10 @@ function call_api(action, callback, options, get_params) {
       // Already reported
     } else if (res.error) {
       errorRaised = true;
-      deferred.reject(res);
+
+      if (USE_PROMISES) {
+        deferred.reject(res);
+      }
       callback(res);
     } else if (includes([200, 400, 401, 404, 420, 500], res.statusCode)) {
       var buffer = "";
@@ -510,16 +515,22 @@ function call_api(action, callback, options, get_params) {
         result = parseResult(buffer, res);
         if (result.error) {
           result.error.http_code = res.statusCode;
-          deferred.reject(result.error);
+          if (USE_PROMISES) {
+            deferred.reject(result.error);
+          }
         } else {
           cacheResults(result, options);
-          deferred.resolve(result);
+          if (USE_PROMISES) {
+            deferred.resolve(result);
+          }
         }
         callback(result);
       });
       res.on("error", function (error) {
         errorRaised = true;
-        deferred.reject(error);
+        if (USE_PROMISES) {
+          deferred.reject(error);
+        }
         callback({ error });
       });
     } else {
@@ -528,7 +539,9 @@ function call_api(action, callback, options, get_params) {
         http_code: res.statusCode,
         name: "UnexpectedResponse"
       };
-      deferred.reject(error);
+      if (USE_PROMISES) {
+        deferred.reject(error);
+      }
       callback({ error });
     }
   };
@@ -550,7 +563,10 @@ function call_api(action, callback, options, get_params) {
   if (isObject(result)) {
     return result;
   }
-  return deferred.promise;
+
+  if (USE_PROMISES) {
+    return deferred.promise;
+  }
 }
 
 function post(url, post_data, boundary, file, callback, options) {

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -386,6 +386,8 @@ function call_api(action, callback, options, get_params) {
     callback = function () {};
   }
 
+  const USE_PROMISES = !options.disable_promises;
+
   let deferred = Q.defer();
   if (options == null) {
     options = {};
@@ -403,7 +405,10 @@ function call_api(action, callback, options, get_params) {
       // Already reported
     } else if (res.error) {
       errorRaised = true;
-      deferred.reject(res);
+
+      if (USE_PROMISES) {
+        deferred.reject(res);
+      }
       callback(res);
     } else if (includes([200, 400, 401, 404, 420, 500], res.statusCode)) {
       let buffer = "";
@@ -419,16 +424,22 @@ function call_api(action, callback, options, get_params) {
         result = parseResult(buffer, res);
         if (result.error) {
           result.error.http_code = res.statusCode;
-          deferred.reject(result.error);
+          if (USE_PROMISES) {
+            deferred.reject(result.error);
+          }
         } else {
           cacheResults(result, options);
-          deferred.resolve(result);
+          if (USE_PROMISES) {
+            deferred.resolve(result);
+          }
         }
         callback(result);
       });
       res.on("error", (error) => {
         errorRaised = true;
-        deferred.reject(error);
+        if (USE_PROMISES) {
+          deferred.reject(error);
+        }
         callback({ error });
       });
     } else {
@@ -437,7 +448,9 @@ function call_api(action, callback, options, get_params) {
         http_code: res.statusCode,
         name: "UnexpectedResponse"
       };
-      deferred.reject(error);
+      if (USE_PROMISES) {
+        deferred.reject(error);
+      }
       callback({ error });
     }
   };
@@ -451,7 +464,10 @@ function call_api(action, callback, options, get_params) {
   if (isObject(result)) {
     return result;
   }
-  return deferred.promise;
+
+  if (USE_PROMISES) {
+    return deferred.promise;
+  }
 }
 
 function post(url, post_data, boundary, file, callback, options) {

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -812,6 +812,24 @@ describe("uploader", function () {
     }, 2000);
   });
 
+  it("should reject with promise rejection by default", function (done) {
+    const spy = sinon.spy();
+
+    cloudinary.v2.uploader.upload_large(EMPTY_IMAGE, () => {});
+
+    function unhandledRejection() {
+      spy();
+    }
+    process.on('unhandledRejection', unhandledRejection);
+
+    // Promises are not disabled meaning we should throw unhandledRejection
+    setTimeout(() => {
+      expect(sinon.assert.called(spy));
+      process.removeListener('unhandledRejection', unhandledRejection);
+      done();
+    }, 2000);
+  });
+
   it("should reject without promise rejection if disable_promises: true", function (done) {
     const spy = sinon.spy();
 

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -794,15 +794,40 @@ describe("uploader", function () {
     });
   });
 
-  it("should reject without promise rejection if error code is returned from the server", function (done) {
-    cloudinary.v2.uploader.upload_large(EMPTY_IMAGE, {
-      tags: UPLOAD_TAGS
-    }, () => {
-      // This should crash
-      // expect(res).to.be(undefined);
-    });
+  it("should reject with promise rejection if disable_promises: false", function (done) {
+    const spy = sinon.spy();
 
+    cloudinary.v2.uploader.upload_large(EMPTY_IMAGE, { disable_promises: false }, () => {});
+
+    function unhandledRejection() {
+      spy();
+      done();
+    }
+    process.on('unhandledRejection', unhandledRejection);
+
+    // Promises are not disabled meaning we should throw unhandledRejection
     setTimeout(() => {
+      expect(sinon.assert.called(spy));
+      process.removeListener('unhandledRejection', unhandledRejection);
+      done();
+    }, 2000);
+  });
+
+  it("should reject without promise rejection if disable_promises: true", function (done) {
+    const spy = sinon.spy();
+
+    cloudinary.v2.uploader.upload_large(EMPTY_IMAGE, { disable_promises: true }, () => {});
+
+    function unhandledRejection() {
+      spy();
+      done();
+    }
+    process.on('unhandledRejection', unhandledRejection);
+
+    // Promises are  disabled meaning unhandledRejection was not called
+    setTimeout(() => {
+      expect(sinon.assert.notCalled(spy));
+      process.removeListener('unhandledRejection', unhandledRejection);
       done();
     }, 2000);
   });

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -801,7 +801,6 @@ describe("uploader", function () {
 
     function unhandledRejection() {
       spy();
-      done();
     }
     process.on('unhandledRejection', unhandledRejection);
 
@@ -820,7 +819,6 @@ describe("uploader", function () {
 
     function unhandledRejection() {
       spy();
-      done();
     }
     process.on('unhandledRejection', unhandledRejection);
 

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -794,6 +794,20 @@ describe("uploader", function () {
     });
   });
 
+  it("should reject without promise rejection if error code is returned from the server", function (done) {
+    cloudinary.v2.uploader.upload_large(EMPTY_IMAGE, {
+      tags: UPLOAD_TAGS
+    }, () => {
+      // This should crash
+      // expect(res).to.be(undefined);
+    });
+
+    setTimeout(() => {
+      done();
+    }, 2000);
+  });
+
+
   it("should reject promise if error code is returned from the server", function () {
     return cloudinary.v2.uploader.upload(EMPTY_IMAGE, {
       tags: UPLOAD_TAGS

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -508,7 +508,7 @@ declare module 'cloudinary' {
         upload_preset?: string;
         use_filename?: boolean;
         chunk_size?: number;
-        disable_promises: boolean;
+        disable_promises?: boolean;
 
         [futureKey: string]: any;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -508,7 +508,7 @@ declare module 'cloudinary' {
         upload_preset?: string;
         use_filename?: boolean;
         chunk_size?: number;
-        disable_promises: number;
+        disable_promises: boolean;
 
         [futureKey: string]: any;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -508,6 +508,7 @@ declare module 'cloudinary' {
         upload_preset?: string;
         use_filename?: boolean;
         chunk_size?: number;
+        disable_promises: number;
 
         [futureKey: string]: any;
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!--
In order to handle unreachable rejected promises. We added a boolean flag called `disable_promises` when this flag is set to true we will not make use of promises in call_api and therefore will not throw a rejected promise
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No