### PR TITLE
Fix return type of api_url function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -706,7 +706,7 @@ declare module 'cloudinary' {
 
             function api_sign_request(params_to_sign: object, api_secret: string): string;
 
-            function api_url(action?: string, options?: ConfigAndUrlOptions): Promise<any>;
+            function api_url(action?: string, options?: ConfigAndUrlOptions): string;
 
             function url(public_id?: string, options?: TransformationOptions | ConfigAndUrlOptions): string;
 


### PR DESCRIPTION
### Brief Summary of Changes
This fixes the return type of the `v2.utils.api_url`

#### What Does This PR Address?
- [x] GitHub issue #482
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
It's just a minor type fix, so it shouldn't affect anything
