### PR TITLE
#486 Fix upload_prefix configuration retrieval

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -24,7 +24,7 @@ var urlLib = require('url');
 
 // eslint-disable-next-line import/order
 
-var _require2 = require("./config"),
+var _require2 = require("./config")(),
     upload_prefix = _require2.upload_prefix;
 
 var isSecure = !(upload_prefix && upload_prefix.slice(0, 5) === 'http:');

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -5,7 +5,7 @@ const Writable = require("stream").Writable;
 const urlLib = require('url');
 
 // eslint-disable-next-line import/order
-const { upload_prefix } = require("./config");
+const { upload_prefix } = require("./config")();
 
 const isSecure = !(upload_prefix && upload_prefix.slice(0, 5) === 'http:');
 const https = isSecure ? require('https') : require('http');


### PR DESCRIPTION
### Brief Summary of Changes
Since the export of config is a function, the destructuring syntax does currently not work and the evaluation, if `HTTP` or `HTTPS` has to be used, will always result in `HTTPS`, ignoring the "secure" state of the upload prefix.

#### What Does This PR Address?
- [x] GitHub issue #486
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
-