### PR TITLE
Remove file extensions from require statements

### DIFF
--- a/lib-es5/v2/index.js
+++ b/lib-es5/v2/index.js
@@ -2,7 +2,7 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var v1 = require('../cloudinary.js');
+var v1 = require('../cloudinary');
 var api = require('./api');
 var uploader = require('./uploader');
 var search = require('./search');

--- a/lib/v2/index.js
+++ b/lib/v2/index.js
@@ -1,4 +1,4 @@
-const v1 = require('../cloudinary.js');
+const v1 = require('../cloudinary');
 const api = require('./api');
 const uploader = require('./uploader');
 const search = require('./search');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dotenv": "4.x",
     "dtslint": "^0.9.1",
     "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.1.0",
+    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.20.2",
     "expect.js": "0.3.x",
     "glob": "^7.1.6",

--- a/test/unit/authToken/authTokenImageTag_spec.js
+++ b/test/unit/authToken/authTokenImageTag_spec.js
@@ -1,4 +1,4 @@
-const cloudinary = require("../../../cloudinary.js");
+const cloudinary = require("../../../cloudinary");
 const commonAuthSetupAndTeardown = require('./utils/commonAuthSetupAndTeardown');
 
 describe("AuthToken tests using image tag", function () {

--- a/test/unit/authToken/authTokenURL_spec.js
+++ b/test/unit/authToken/authTokenURL_spec.js
@@ -1,4 +1,4 @@
-const cloudinary = require("../../../cloudinary.js");
+const cloudinary = require("../../../cloudinary");
 const commonAuthSetupAndTeardown = require('./utils/commonAuthSetupAndTeardown');
 
 describe("AuthToken tests using cloudinary.url and a private CDN", function () {

--- a/test/unit/authToken/authTokenUtils_spec.js
+++ b/test/unit/authToken/authTokenUtils_spec.js
@@ -1,4 +1,4 @@
-const cloudinary = require("../../../cloudinary.js");
+const cloudinary = require("../../../cloudinary");
 const commonAuthSetupAndTeardown = require('./utils/commonAuthSetupAndTeardown');
 
 const utils = cloudinary.utils;

--- a/test/unit/authToken/utils/commonAuthSetupAndTeardown.js
+++ b/test/unit/authToken/utils/commonAuthSetupAndTeardown.js
@@ -1,4 +1,4 @@
-const cloudinary = require("../../../../cloudinary.js");
+const cloudinary = require("../../../../cloudinary");
 const createTestConfig = require('../../../testUtils/createTestConfig');
 
 const AUTH_KEY_1 = "00112233FF99";

--- a/test/unit/cloudinaryUtils/getUserAgent.spec.js
+++ b/test/unit/cloudinaryUtils/getUserAgent.spec.js
@@ -1,5 +1,5 @@
 
-const cloudinary = require("../../../cloudinary.js");
+const cloudinary = require("../../../cloudinary");
 
 describe("getUserAgent", function () {
   var platform = "";

--- a/test/unit/cloudinary_spec.js
+++ b/test/unit/cloudinary_spec.js
@@ -1,4 +1,4 @@
-const cloudinary = require("../../cloudinary.js");
+const cloudinary = require("../../cloudinary");
 const createTestConfig = require('../testUtils/createTestConfig');
 
 describe("cloudinary", function () {

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -1,5 +1,5 @@
 
-const cloudinary = require("../../cloudinary.js");
+const cloudinary = require("../../cloudinary");
 
 
 describe("config", function () {


### PR DESCRIPTION
### Brief Summary of Changes
In newer eslint plugins, the check against require statements is more strict, and now file extensions are no longer considered valid.



#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [X] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No
