### PR TITLE
Allow 'multi' and 'sprite' with urls, add 'download_generated_sprite' and 'download_multi' methods

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -264,36 +264,83 @@ exports.text = function text(content, callback) {
   });
 };
 
+/**
+ * Generate a sprite by merging multiple images into a single large image for reducing network overhead and bypassing
+ * download limitations.
+ *
+ * The process produces 2 files as follows:
+ * - A single image file containing all the images with the specified tag (PNG by default).
+ * - A CSS file that includes the style class names and the location of the individual images in the sprite.
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Function}     callback   Callback function
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @return {Object}
+ */
 exports.generate_sprite = function generate_sprite(tag, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
   return call_api("sprite", callback, options, function () {
-    var transformation = utils.generate_transformation_string(extend({}, options, {
-      fetch_format: options.format
-    }));
-    return [{
-      timestamp: utils.timestamp(),
-      tag: tag,
-      transformation: transformation,
-      async: options.async,
-      notification_url: options.notification_url
-    }];
+    return [utils.build_multi_and_sprite_params(tag, options)];
   });
 };
 
+/**
+ * Returns a signed url to download a sprite
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @returns {string}
+ */
+exports.download_generated_sprite = function download_generated_sprite(tag) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  return utils.api_download_url("sprite", utils.build_multi_and_sprite_params(tag, options), options);
+};
+
+/**
+ * Returns a signed url to download a single animated image (GIF, PNG or WebP), video (MP4 or WebM) or a single PDF from
+ * multiple image assets.
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @returns {string}
+ */
+exports.download_multi = function download_multi(tag) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  return utils.api_download_url("multi", utils.build_multi_and_sprite_params(tag, options), options);
+};
+
+/**
+ * Creates either a single animated image (GIF, PNG or WebP), video (MP4 or WebM) or a single PDF from multiple image
+ * assets.
+ *
+ * Each asset is included as a single frame of the resulting animated image/video, or a page of the PDF (sorted
+ * alphabetically by their Public ID).
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Function}     callback   Callback function
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @return {Object}
+ */
 exports.multi = function multi(tag, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
   return call_api("multi", callback, options, function () {
-    var transformation = utils.generate_transformation_string(extend({}, options));
-    return [{
-      timestamp: utils.timestamp(),
-      tag: tag,
-      transformation: transformation,
-      format: options.format,
-      async: options.async,
-      notification_url: options.notification_url
-    }];
+    return [utils.build_multi_and_sprite_params(tag, options)];
   });
 };
 

--- a/lib-es5/v2/uploader.js
+++ b/lib-es5/v2/uploader.js
@@ -35,3 +35,5 @@ exports.upload_tag_params = uploader.upload_tag_params;
 exports.upload_url = uploader.upload_url;
 exports.image_upload_tag = uploader.image_upload_tag;
 exports.unsigned_image_upload_tag = uploader.unsigned_image_upload_tag;
+exports.download_generated_sprite = uploader.download_generated_sprite;
+exports.download_multi = uploader.download_multi;

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -211,36 +211,76 @@ exports.text = function text(content, callback, options = {}) {
   });
 };
 
+/**
+ * Generate a sprite by merging multiple images into a single large image for reducing network overhead and bypassing
+ * download limitations.
+ *
+ * The process produces 2 files as follows:
+ * - A single image file containing all the images with the specified tag (PNG by default).
+ * - A CSS file that includes the style class names and the location of the individual images in the sprite.
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Function}     callback   Callback function
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @return {Object}
+ */
 exports.generate_sprite = function generate_sprite(tag, callback, options = {}) {
   return call_api("sprite", callback, options, function () {
-    const transformation = utils.generate_transformation_string(extend({}, options, {
-      fetch_format: options.format
-    }));
-    return [
-      {
-        timestamp: utils.timestamp(),
-        tag: tag,
-        transformation: transformation,
-        async: options.async,
-        notification_url: options.notification_url
-      }
-    ];
+    return [utils.build_multi_and_sprite_params(tag, options)];
   });
 };
 
+
+/**
+ * Returns a signed url to download a sprite
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @returns {string}
+ */
+exports.download_generated_sprite = function download_generated_sprite(tag, options = {}) {
+  return utils.api_download_url("sprite", utils.build_multi_and_sprite_params(tag, options), options);
+}
+
+/**
+ * Returns a signed url to download a single animated image (GIF, PNG or WebP), video (MP4 or WebM) or a single PDF from
+ * multiple image assets.
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @returns {string}
+ */
+exports.download_multi = function download_multi(tag, options = {}) {
+  return utils.api_download_url("multi", utils.build_multi_and_sprite_params(tag, options), options);
+}
+
+/**
+ * Creates either a single animated image (GIF, PNG or WebP), video (MP4 or WebM) or a single PDF from multiple image
+ * assets.
+ *
+ * Each asset is included as a single frame of the resulting animated image/video, or a page of the PDF (sorted
+ * alphabetically by their Public ID).
+ *
+ * @param {String|Object} tag     A string specifying a tag that indicates which images to include or an object
+ *                                which includes options and image URLs.
+ * @param {Function}     callback   Callback function
+ * @param {Object}       options  Configuration options. If options are passed as the first parameter, this parameter
+ *                                should be empty
+ *
+ * @return {Object}
+ */
 exports.multi = function multi(tag, callback, options = {}) {
   return call_api("multi", callback, options, function () {
-    const transformation = utils.generate_transformation_string(extend({}, options));
-    return [
-      {
-        timestamp: utils.timestamp(),
-        tag: tag,
-        transformation: transformation,
-        format: options.format,
-        async: options.async,
-        notification_url: options.notification_url
-      }
-    ];
+    return [utils.build_multi_and_sprite_params(tag, options)];
   });
 };
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -283,6 +283,38 @@ function process_radius(radius) {
   return radius.map(normalize_expression).join(':');
 }
 
+function build_multi_and_sprite_params(tagOrOptions, options) {
+  let tag = null;
+  if (typeof tagOrOptions === 'string') {
+    tag = tagOrOptions;
+  } else {
+    if (isEmpty(options)) {
+      options = tagOrOptions;
+    } else {
+      throw new Error('First argument must be a tag when additional options are passed');
+    }
+    tag = null;
+  }
+  if (!options && !tag) {
+    throw new Error('Either tag or urls are required')
+  }
+  if (!options) {
+    options = {}
+  }
+  const urls = options.urls
+  const transformation = generate_transformation_string(extend({}, options, {
+    fetch_format: options.format
+  }));
+  return {
+    tag,
+    transformation,
+    urls,
+    timestamp: utils.timestamp(),
+    async: options.async,
+    notification_url: options.notification_url
+  };
+}
+
 function build_upload_params(options) {
   let params = {
     access_mode: options.access_mode,
@@ -1073,6 +1105,18 @@ function download_backedup_asset(asset_id, version_id, options = {}) {
 }
 
 /**
+ * Utility method to create a signed URL for specified resources.
+ * @param action
+ * @param params
+ * @param options
+ */
+function api_download_url(action, params, options) {
+  const download_params = {...params, mode: "download"}
+  let cloudinary_params = exports.sign_request(download_params, options);
+  return exports.api_url(action, options) + "?" + hashToQuery(cloudinary_params);
+}
+
+/**
  * Returns a URL that when invokes creates an archive and returns it.
  * @param {object} options
  * @param {string} [options.resource_type="image"] The resource type of files to include in the archive.
@@ -1107,10 +1151,10 @@ function download_backedup_asset(asset_id, version_id, options = {}) {
  * @return {String} archive url
  */
 function download_archive_url(options = {}) {
-  let cloudinary_params = exports.sign_request(exports.archive_params(merge(options, {
+  const params = exports.archive_params(merge(options, {
     mode: "download"
-  })), options);
-  return exports.api_url("generate_archive", options) + "?" + hashToQuery(cloudinary_params);
+  }))
+  return api_download_url("generate_archive", params, options)
 }
 
 /**
@@ -1454,6 +1498,8 @@ exports.NOP = function () {};
 exports.generate_auth_token = generate_auth_token;
 exports.getUserAgent = getUserAgent;
 exports.build_upload_params = build_upload_params;
+exports.build_multi_and_sprite_params = build_multi_and_sprite_params;
+exports.api_download_url = api_download_url;
 exports.timestamp = () => Math.floor(new Date().getTime() / 1000);
 exports.option_consume = consumeOption; // for backwards compatibility
 exports.build_array = toArray; // for backwards compatibility

--- a/lib/v2/uploader.js
+++ b/lib/v2/uploader.js
@@ -33,3 +33,5 @@ exports.upload_tag_params = uploader.upload_tag_params;
 exports.upload_url = uploader.upload_url;
 exports.image_upload_tag = uploader.image_upload_tag;
 exports.unsigned_image_upload_tag = uploader.unsigned_image_upload_tag;
+exports.download_generated_sprite = uploader.download_generated_sprite;
+exports.download_multi = uploader.download_multi;

--- a/test/testUtils/assertions/beAMulti.js
+++ b/test/testUtils/assertions/beAMulti.js
@@ -1,0 +1,54 @@
+const url = require("url");
+
+const ERRORS = {
+  FIELD_VERSION_MUST_BE_NUMBER: `expected sprite to contain mandatory field 'version' of type string`,
+  FIELD_VERSION_MUST_NOT_BE_NUMBER: `expected sprite not to contain mandatory field 'version' of type string`,
+  FIELD_VALUE_MUST_BE_STRING: name => `expected sprite to contain mandatory field '${name}' of type string`,
+  FIELD_VALUE_MUST_NOT_BE_STRING: name => `expected sprite not to contain mandatory field '${name}' of type string`,
+  FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME: (name, protocol, formats) => `expected field '${name}' to contain a URL with protocol '${protocol}' and one of formats: ${formats}`,
+  FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME: (name, protocol, formats) => `expected field '${name}' not to contain a URL with protocol '${protocol}' and one of formats: ${formats}`
+}
+
+function matchesSchema (urlStr, protocol, formats) {
+  const urlObj = url.parse(urlStr);
+  return urlObj.protocol === `${protocol}:` && formats.some(format => urlObj.pathname.endsWith(format));
+}
+
+/**
+ * Asserts that a given object is a multi object.
+ *
+ * @returns {expect.Assertion}
+ */
+expect.Assertion.prototype.beAMulti = function () {
+  const multi = this.obj;
+
+  const stringKeys = ["url", "secure_url", "public_id"];
+  const supportedFormats = ["gif", "png", "webp", "webm", "mp4", "pdf"];
+
+  // Check that certain mandatory keys are of the 'string' type
+  stringKeys.forEach((key) => {
+    this.assert(typeof multi[key] === "string", function () {
+      return ERRORS.FIELD_VALUE_MUST_BE_STRING(key);
+    }, function () {
+      return ERRORS.FIELD_VALUE_MUST_NOT_BE_STRING(key);
+    });
+  });
+
+  this.assert(typeof multi.version === "number", function () {
+    return ERRORS.FIELD_VERSION_MUST_BE_NUMBER;
+  }, function () {
+    return ERRORS.FIELD_VERSION_MUST_NOT_BE_NUMBER;
+  });
+
+  // Check that 'url' fields match the protocol and file format
+  this.assert(matchesSchema(multi.url, "http", supportedFormats), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("url", "http", supportedFormats);
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("url", "http", supportedFormats);
+  });
+  this.assert(matchesSchema(multi.secure_url, "https", supportedFormats), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("secure_url", "https", supportedFormats);
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("secure_url", "https", supportedFormats);
+  });
+}

--- a/test/testUtils/assertions/beASignedDownloadUrl.js
+++ b/test/testUtils/assertions/beASignedDownloadUrl.js
@@ -1,0 +1,70 @@
+const cloudinary = require("../../../cloudinary");
+const url = require("url");
+const isEmpty = require("lodash/isEmpty");
+const isEqual = require("lodash/isEqual");
+
+const ERRORS = {
+  MUST_CONTAIN_QUERY_PARAMETER: name => `expected query parameters to contain mandatory parameter: ${name}`,
+  MUST_NOT_CONTAIN_QUERY_PARAMETER: name => `expected query parameters not to contain parameter: ${name}`,
+  PATH_MUST_END_WITH: part => `expected path to end with: ${part}`,
+  PATH_MUST_NOT_END_WITH: part => `expected path not to end with: ${part}`,
+  FIELD_MUST_EQUAL_VALUE: (key, value, resultValue) => `expected field ${key} to equal ${value} but got ${resultValue} instead`,
+  FIELD_MUST_NOT_EQUAL_VALUE: (key, value) => `expected field ${key} not to equal ${value}`
+}
+
+/**
+ * Asserts that a given string is a signed url.
+ *
+ * @param {string} [path]   Path that the url should end with
+ * @param {Object} [params] Query paraneters that should be present in the url
+ *
+ * @returns {expect.Assertion}
+ */
+expect.Assertion.prototype.beASignedDownloadUrl = function (path, params) {
+  const apiUrl = this.obj;
+
+  const urlOptions = url.parse(apiUrl, true)
+  const queryParams = urlOptions.query;
+
+  const defaultParams = {
+    api_key: cloudinary.config().api_key,
+    mode: "download"
+  };
+  const expectedParams = Object.assign(defaultParams, params);
+
+  // Rename PHP-style multi-value params to strip '[]' from their names, e.g. urls[] -> urls
+  for (let param in queryParams) {
+    if (param.endsWith("[]")) {
+      queryParams[param.slice(0, -2)] = queryParams[param];
+      delete queryParams[param];
+    }
+  }
+
+  this.assert("timestamp" in queryParams, function () {
+    return ERRORS.MUST_CONTAIN_QUERY_PARAMETER("timestamp");
+  }, function () {
+    return ERRORS.MUST_NOT_CONTAIN_QUERY_PARAMETER("timestamp");
+  });
+
+  this.assert("signature" in queryParams, function () {
+    return ERRORS.MUST_CONTAIN_QUERY_PARAMETER("signature");
+  }, function () {
+    return ERRORS.MUST_NOT_CONTAIN_QUERY_PARAMETER("signature");
+  });
+
+  if (!isEmpty(path)) {
+    this.assert(urlOptions.pathname.endsWith(path), function () {
+      return ERRORS.PATH_MUST_END_WITH(path);
+    }, function () {
+      return ERRORS.PATH_MUST_NOT_END_WITH(path);
+    });
+  }
+
+  Object.keys(expectedParams).forEach((key) => {
+    this.assert(isEqual(expectedParams[key], queryParams[key]), function () {
+      return ERRORS.FIELD_MUST_EQUAL_VALUE(key, expectedParams[key], queryParams[key]);
+    }, function() {
+      return ERRORS.FIELD_MUST_NOT_EQUAL_VALUE(key, expectedParams[key]);
+    });
+  });
+};

--- a/test/testUtils/assertions/beASprite.js
+++ b/test/testUtils/assertions/beASprite.js
@@ -1,0 +1,96 @@
+const url = require("url");
+
+const ERRORS = {
+  FIELD_VERSION_MUST_BE_NUMBER: `expected sprite to contain mandatory field 'version' of type number`,
+  FIELD_VERSION_MUST_NOT_BE_NUMBER: `expected sprite not to contain mandatory field 'version' of type number`,
+  MUST_CONTAIN_IMAGE_INFOS: `expected sprite to contain mandatory field: 'image_infos'`,
+  MUST_NOT_CONTAIN_IMAGE_INFOS: `expected sprite not to contain mandatory field: 'image_infos'`,
+  FIELD_VALUE_MUST_BE_STRING: name => `expected sprite to contain mandatory field '${name}' of type string`,
+  FIELD_VALUE_MUST_NOT_BE_STRING: name => `expected sprite not to contain mandatory field '${name}' of type string`,
+  IMAGE_INFOS_VALUE_MUST_BE_NUMBER: name => `expected 'image_infos' item to contain mandatory field '${name}' of type number`,
+  IMAGE_INFOS_VALUE_MUST_NOT_BE_NUMBER: name => `expected 'image_infos' item not to contain mandatory field '${name}' of type number`,
+  FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME: (name, protocol, format) => `expected field '${name}' to contain a URL with protocol '${protocol}' and format '${format}'`,
+  FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME: (name, protocol, format) => `expected field '${name}' not to contain a URL with protocol '${protocol}' and format '${format}'`
+}
+
+function matchesSchema (urlStr, protocol, format) {
+  const urlObj = url.parse(urlStr);
+  let isValid = urlObj.protocol === `${protocol}:`;
+  if (format) {
+    isValid = isValid && urlObj.pathname.endsWith(`.${format}`)
+  }
+  return isValid
+}
+
+/**
+ * Asserts that a given object is a sprite object.
+ *
+ * @returns {expect.Assertion}
+ */
+expect.Assertion.prototype.beASprite = function (format=null) {
+  const sprite = this.obj;
+  const stringKeys = ["css_url", "image_url", "json_url", "secure_css_url", "secure_image_url", "secure_json_url", "public_id"];
+  const imageInfosKeys = ["width", "height", "x", "y"];
+
+  // Check that certain mandatory keys are of the 'string' type
+  stringKeys.forEach((key) => {
+    this.assert(typeof sprite[key] === "string", function () {
+      return ERRORS.FIELD_VALUE_MUST_BE_STRING(key);
+    }, function () {
+      return ERRORS.FIELD_VALUE_MUST_NOT_BE_STRING(key);
+    });
+  });
+  this.assert(typeof sprite.version === "number", function () {
+    return ERRORS.FIELD_VERSION_MUST_BE_NUMBER;
+  }, function () {
+    return ERRORS.FIELD_VERSION_MUST_NOT_BE_NUMBER;
+  });
+  this.assert("image_infos" in sprite, function () {
+    return ERRORS.MUST_CONTAIN_IMAGE_INFOS;
+  }, function () {
+    return ERRORS.MUST_NOT_CONTAIN_IMAGE_INFOS;
+  });
+
+  // Check that all keys of 'image_infos' field are of the 'number' type
+  Object.entries(sprite.image_infos).forEach(([key, imageInfos]) => {
+    imageInfosKeys.forEach((imageInfoKey) => {
+      this.assert(typeof imageInfos[imageInfoKey] === "number", function () {
+        return ERRORS.IMAGE_INFOS_VALUE_MUST_BE_NUMBER(imageInfoKey);
+      }, function () {
+        return ERRORS.IMAGE_INFOS_VALUE_MUST_NOT_BE_NUMBER(imageInfoKey);
+      });
+    });
+  });
+
+  // Check that 'url' fields match the protocol and file format
+  this.assert(matchesSchema(sprite.css_url, "http", "css"), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("css_url", "http", "css");
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("css_url", "http", "css");
+  });
+  this.assert(matchesSchema(sprite.image_url, "http", format), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("image_url", "http", format);
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("image_url", "http", format);
+  });
+  this.assert(matchesSchema(sprite.json_url, "http", "json"), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("json_url", "http", "json");
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("json_url", "http", "json");
+  });
+  this.assert(matchesSchema(sprite.secure_css_url, "https", "css"), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("secure_css_url", "https", "css");
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("secure_css_url", "https", "css");
+  });
+  this.assert(matchesSchema(sprite.secure_image_url, "https", format), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("secure_image_url", "https", format);
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("secure_image_url", "https", format);
+  });
+  this.assert(matchesSchema(sprite.secure_json_url, "https", "json"), function () {
+    return ERRORS.FIELD_URL_MUST_BE_ACCORDING_TO_THE_SCHEME("secure_json_url", "https", "json");
+  }, function () {
+    return ERRORS.FIELD_URL_MUST_NOT_BE_ACCORDING_TO_THE_SCHEME("secure_json_url", "https", "json");
+  });
+};


### PR DESCRIPTION
### Brief Summary of Changes
User can now pass ‘urls’ as a source of sprite/multi.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
