### PR TITLE
fixed font_family encoding

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -826,7 +826,7 @@ function url(public_id) {
   var prefix = unsigned_url_prefix(public_id, cloud_name, private_cdn, cdn_subdomain, secure_cdn_subdomain, cname, secure, secure_distribution);
   var resultUrl = [prefix, resource_type, type, signature, transformation, version, public_id].filter(function (part) {
     return part != null && part !== '';
-  }).join('/').replace(' ', '%20');
+  }).join('/').replace(/ /g, '%20');
   if (sign_url && !isEmpty(auth_token)) {
     auth_token.url = urlParse(resultUrl).path;
     var token = generate_token(auth_token);

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -758,7 +758,7 @@ function url(public_id, options = {}) {
   );
   let resultUrl = [prefix, resource_type, type, signature, transformation, version, public_id].filter(function (part) {
     return (part != null) && part !== '';
-  }).join('/').replace(' ', '%20');
+  }).join('/').replace(/ /g, '%20');
   if (sign_url && !isEmpty(auth_token)) {
     auth_token.url = urlParse(resultUrl).path;
     let token = generate_token(auth_token);

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -806,7 +806,7 @@ describe("utils", function () {
               font_size: "18"
             }
           });
-        expect(url).to.eql("http://res.cloudinary.com/sdk-test/image/upload/l_text:Times%20New%20Roman_18:sample%20text/sample");
+        expect(url).to.eql(`http://res.cloudinary.com/${cloud_name}/image/upload/l_text:Times%20New%20Roman_18:sample%20text/sample`);
       });
       it("should encode raw_transformation with %20", () => {
         const transformation = "l_text:Times New Roman_109_line_spacing_1:Heading,x_197,y_202";
@@ -814,7 +814,7 @@ describe("utils", function () {
           {
             raw_transformation: transformation
           });
-        expect(url).to.eql("http://res.cloudinary.com/sdk-test/image/upload/l_text:Times%20New%20Roman_109_line_spacing_1:Heading,x_197,y_202/sample");
+        expect(url).to.eql(`http://res.cloudinary.com/${cloud_name}/image/upload/l_text:Times%20New%20Roman_109_line_spacing_1:Heading,x_197,y_202/sample`);
       });
     });
     describe("streaming_profile", function () {

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -797,6 +797,25 @@ describe("utils", function () {
           expect(["test", opt]).to.produceUrl(`http://res.cloudinary.com/${cloud_name}/image/upload/h_100,${letter}_text:hello,w_100/test`).and.emptyOptions();
         });
       });
+      it("should encode font_family with %20", () => {
+        let url = cloudinary.utils.url("sample",
+          {
+            overlay: {
+              text: "sample text",
+              font_family: "Times New Roman",
+              font_size: "18"
+            }
+          });
+        expect(url).to.eql("http://res.cloudinary.com/sdk-test/image/upload/l_text:Times%20New%20Roman_18:sample%20text/sample");
+      });
+      it("should encode raw_transformation with %20", () => {
+        const transformation = "l_text:Times New Roman_109_line_spacing_1:Heading,x_197,y_202";
+        let url = cloudinary.utils.url("sample",
+          {
+            raw_transformation: transformation
+          });
+        expect(url).to.eql("http://res.cloudinary.com/sdk-test/image/upload/l_text:Times%20New%20Roman_109_line_spacing_1:Heading,x_197,y_202/sample");
+      });
     });
     describe("streaming_profile", function () {
       it('should support streaming_profile in options', function () {


### PR DESCRIPTION
### Brief Summary of Changes
font spacing such as Times New Roman resulted in the following encoding `l_text:Times%20New Roman_109_line`
only the first occurrence was encoded. 
Fixed to encode all 

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

