### PR TITLE
Escape all instances of single and double quotes, not just the first

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1261,7 +1261,7 @@ function join_pair(key, value) {
  * @return {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
-  return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+  return isString(value) ? value.replace(/\"/g, '&#34;').replace(/\'/g, '&#39;') : value;
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1158,7 +1158,7 @@ function join_pair(key, value) {
  * @return {*} Encoded string or original value if not a string
  */
 function escapeQuotes(value) {
-  return isString(value) ? value.replace('"', '&#34;').replace("'", '&#39;') : value;
+  return isString(value) ? value.replace(/\"/g, '&#34;').replace(/\'/g, '&#39;') : value;
 }
 
 /**

--- a/test/unit/tags/image_spec.js
+++ b/test/unit/tags/image_spec.js
@@ -121,8 +121,8 @@ describe('image helper', function () {
   });
   it("should escape quotes in html attributes", function() {
     expect(cloudinary.image("sample.jpg", {
-      alt: "asdfg\"'asdf"
-    })).to.eql(`<img src='${UPLOAD_PATH}/sample.jpg' alt='asdfg&#34;&#39;asdf'/>`);
+      alt: "here 'is' my \"alt\" escaped"
+    })).to.eql(`<img src='${UPLOAD_PATH}/sample.jpg' alt='here &#39;is&#39; my &#34;alt&#34; escaped'/>`);
   });
 
   describe(":client_hints", function () {


### PR DESCRIPTION
### Brief Summary of Changes
cloudinary.image does not correctly escape single and double quotes in attributes. The replacements apply only to the first instance of single or double quotes, and not all instances. Switched the replace to a regex with the global flag.

#### What Does This PR Address?
- [x] GitHub issue (#504 )
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No
