### PR TITLE
Fix incorrect normalization of e_preview:duration

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -148,7 +148,10 @@ function textStyle(layer) {
  * @return {Object|String} A normalized String of the input value if possible otherwise the value itself
  */
 function normalize_expression(expression) {
-  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
+  // Exclude(Don't normalize) expressions that are variable strings foo_!width!
+  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
+  // Exclude(Don't normalize) if expression is not a string, or is an empty string
+  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/) || expression.includes(':')) {
     return expression;
   }
 

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -149,12 +149,10 @@ function textStyle(layer) {
  */
 function normalize_expression(expression) {
   // Exclude(Don't normalize) expressions that are variable strings foo_!width!
-  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
   // Exclude(Don't normalize) if expression is not a string, or is an empty string
-  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/) || expression.includes(':')) {
+  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
     return expression;
   }
-
   var operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\^|\\+|\\*";
   var operatorsPattern = "((" + operators + ")(?=[ _]))";
   var operatorsReplaceRE = new RegExp(operatorsPattern, "g");
@@ -162,7 +160,8 @@ function normalize_expression(expression) {
     return CONDITIONAL_OPERATORS[match];
   });
 
-  var predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
+  var predefinedVarsPattern = "(?<![\$:])(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
   var userVariablePattern = '(\\$_*[^_ ]+)';
   var variablesReplaceRE = new RegExp(`${userVariablePattern}|${predefinedVarsPattern}`, "g");
   expression = expression.replace(variablesReplaceRE, function (match) {
@@ -1640,6 +1639,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.normalize_expression = normalize_expression;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -136,18 +136,17 @@ function textStyle(layer) {
  */
 function normalize_expression(expression) {
   // Exclude(Don't normalize) expressions that are variable strings foo_!width!
-  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
   // Exclude(Don't normalize) if expression is not a string, or is an empty string
-  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/) || expression.includes(':')) {
+  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
     return expression;
   }
-
   const operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\^|\\+|\\*";
   const operatorsPattern = "((" + operators + ")(?=[ _]))";
   const operatorsReplaceRE = new RegExp(operatorsPattern, "g");
   expression = expression.replace(operatorsReplaceRE, match => CONDITIONAL_OPERATORS[match]);
 
-  const predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
+  const predefinedVarsPattern = "(?<![\$:])(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
   const userVariablePattern = '(\\$_*[^_ ]+)';
   const variablesReplaceRE = new RegExp(`${userVariablePattern}|${predefinedVarsPattern}`, "g");
   expression = expression.replace(variablesReplaceRE, (match) => (PREDEFINED_VARS[match] || match));
@@ -1506,6 +1505,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.normalize_expression = normalize_expression;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -135,7 +135,10 @@ function textStyle(layer) {
  * @return {Object|String} A normalized String of the input value if possible otherwise the value itself
  */
 function normalize_expression(expression) {
-  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/)) {
+  // Exclude(Don't normalize) expressions that are variable strings foo_!width!
+  // Exclude(Don't normalize) expressions that contain a semicolon (e_preview:duration)
+  // Exclude(Don't normalize) if expression is not a string, or is an empty string
+  if (!isString(expression) || expression.length === 0 || expression.match(/^!.+!$/) || expression.includes(':')) {
     return expression;
   }
 

--- a/test/unit/cloudinary_spec.js
+++ b/test/unit/cloudinary_spec.js
@@ -879,4 +879,17 @@ describe("cloudinary", function () {
     const result = cloudinary.utils.url("sample", options);
     expect(result).to.contain("$aheight_300,$mywidth_100/c_scale,h_3_mul_ih_add_$aheight,w_3_add_$mywidth_mul_3_add_4_div_2_mul_iw_mul_$mywidth");
   });
+
+  it('should support duration in video preview', () => {
+    const expected_url = `https://example.com/e_preview:duration_2/video_id`;
+    const options = {
+      transformation: 'foo:duration',
+      resource_type: 'video',
+      effect: "preview:duration_2"
+    };
+
+    const url = cloudinary.utils.url("video_id", options, expected_url, {});
+
+    expect(url.includes('preview:duration_2')).to.be(true);
+  });
 });

--- a/test/unit/cloudinary_spec.js
+++ b/test/unit/cloudinary_spec.js
@@ -879,17 +879,4 @@ describe("cloudinary", function () {
     const result = cloudinary.utils.url("sample", options);
     expect(result).to.contain("$aheight_300,$mywidth_100/c_scale,h_3_mul_ih_add_$aheight,w_3_add_$mywidth_mul_3_add_4_div_2_mul_iw_mul_$mywidth");
   });
-
-  it('should support duration in video preview', () => {
-    const expected_url = `https://example.com/e_preview:duration_2/video_id`;
-    const options = {
-      transformation: 'foo:duration',
-      resource_type: 'video',
-      effect: "preview:duration_2"
-    };
-
-    const url = cloudinary.utils.url("video_id", options, expected_url, {});
-
-    expect(url.includes('preview:duration_2')).to.be(true);
-  });
 });

--- a/test/unit/normalize_expression_spec.js
+++ b/test/unit/normalize_expression_spec.js
@@ -1,0 +1,49 @@
+const cloudinary = require("../../cloudinary");
+
+describe("Tests for normalize_expression", function () {
+  it('Normalizes duration with ":" correctly', () => {
+    const NORMALIZATION_EXAMPLES = {
+      'None is not affected': ['None', 'None'],
+      'empty string is not affected': ['', ''],
+      'single space is replaced with a single underscore': [' ', '_'],
+      'blank string is replaced with a single underscore': ['   ', '_'],
+      'underscore is not affected': ['_', '_'],
+      'sequence of underscores and spaces is replaced with a single underscore': [' _ __  _', '_'],
+      'arbitrary text is not affected': ['foobar', 'foobar'],
+      'double ampersand replaced with and operator': ['foo && bar', 'foo_and_bar'],
+      'double ampersand with no space at the end is not affected': ['foo&&bar', 'foo&&bar'],
+      'width recognized as variable and replaced with w': ['width', 'w'],
+      'initial aspect ratio recognized as variable and replaced with iar': ['initial_aspect_ratio', 'iar'],
+      'duration is recognized as a variable and replaced with du': ['duration', 'du'],
+      'duration after : is not a variable and is not affected': ['preview:duration_2', 'preview:duration_2'],
+      '$width recognized as user variable and not affected': ['$width', '$width'],
+      '$initial_aspect_ratio recognized as user variable followed by aspect_ratio variable': [
+        '$initial_aspect_ratio',
+        '$initial_ar'
+      ],
+      '$mywidth recognized as user variable and not affected': ['$mywidth', '$mywidth'],
+      '$widthwidth recognized as user variable and not affected': ['$widthwidth', '$widthwidth'],
+      '$_width recognized as user variable and not affected': ['$_width', '$_width'],
+      '$__width recognized as user variable and not affected': ['$__width', '$_width'],
+      '$$width recognized as user variable and not affected': ['$$width', '$$width'],
+      '$height recognized as user variable and not affected': ['$height_100', '$height_100'],
+      '$heightt_100 recognized as user variable and not affected': ['$heightt_100', '$heightt_100'],
+      '$$height_100 recognized as user variable and not affected': ['$$height_100', '$$height_100'],
+      '$heightmy_100 recognized as user variable and not affected': ['$heightmy_100', '$heightmy_100'],
+      '$myheight_100 recognized as user variable and not affected': ['$myheight_100', '$myheight_100'],
+      '$heightheight_100 recognized as user variable and not affected': [
+        '$heightheight_100',
+        '$heightheight_100'
+      ],
+      '$theheight_100 recognized as user variable and not affected': ['$theheight_100', '$theheight_100'],
+      '$__height_100 recognized as user variable and not affected': ['$__height_100', '$_height_100']
+    }
+
+    Object.keys(NORMALIZATION_EXAMPLES).forEach((descKey) => {
+      const [input, expectedOutput] = NORMALIZATION_EXAMPLES[descKey];
+      const realOutput = cloudinary.utils.normalize_expression(input);
+
+      expect(realOutput).to.equal(expectedOutput);
+    });
+  });
+});


### PR DESCRIPTION
### Brief Summary of Changes
Fix incorrect normalization of e_preview:duration
Before this PR, e_preview:duration was incorrect normalized to e_preview:du.

This PR fixes that by preventing an expression with `:` to be normalized

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [ ] No

