### PR TITLE
Feature/prevent duplicate search fields in search api

### DIFF
--- a/lib-es5/v2/search.js
+++ b/lib-es5/v2/search.js
@@ -42,13 +42,27 @@ var Search = function () {
   }, {
     key: 'aggregate',
     value: function aggregate(value) {
-      this.query_hash.aggregate.push(value);
+      var found = this.query_hash.aggregate.find(function (v) {
+        return v === value;
+      });
+
+      if (!found) {
+        this.query_hash.aggregate.push(value);
+      }
+
       return this;
     }
   }, {
     key: 'with_field',
     value: function with_field(value) {
-      this.query_hash.with_field.push(value);
+      var found = this.query_hash.with_field.find(function (v) {
+        return v === value;
+      });
+
+      if (!found) {
+        this.query_hash.with_field.push(value);
+      }
+
       return this;
     }
   }, {
@@ -59,7 +73,20 @@ var Search = function () {
       var sort_bucket = void 0;
       sort_bucket = {};
       sort_bucket[field_name] = dir;
-      this.query_hash.sort_by.push(sort_bucket);
+
+      // Check if this field name is already stored in the hash
+      var previously_sorted_obj = this.query_hash.sort_by.find(function (sort_by) {
+        return sort_by[field_name];
+      });
+
+      // Since objects are references in Javascript, we can update the reference we found
+      // For example,
+      if (previously_sorted_obj) {
+        previously_sorted_obj[field_name] = dir;
+      } else {
+        this.query_hash.sort_by.push(sort_bucket);
+      }
+
       return this;
     }
   }, {

--- a/lib/v2/search.js
+++ b/lib/v2/search.js
@@ -1,5 +1,5 @@
 const api = require('./api');
-const { isEmpty, isNumber } = require('../utils');
+const {isEmpty, isNumber} = require('../utils');
 
 const Search = class Search {
   constructor() {
@@ -54,12 +54,22 @@ const Search = class Search {
   }
 
   aggregate(value) {
-    this.query_hash.aggregate.push(value);
+    const found = this.query_hash.aggregate.find(v => v === value);
+
+    if (!found) {
+      this.query_hash.aggregate.push(value);
+    }
+
     return this;
   }
 
   with_field(value) {
-    this.query_hash.with_field.push(value);
+    const found = this.query_hash.with_field.find(v => v === value);
+
+    if (!found) {
+      this.query_hash.with_field.push(value);
+    }
+
     return this;
   }
 
@@ -67,7 +77,18 @@ const Search = class Search {
     let sort_bucket;
     sort_bucket = {};
     sort_bucket[field_name] = dir;
-    this.query_hash.sort_by.push(sort_bucket);
+
+    // Check if this field name is already stored in the hash
+    const previously_sorted_obj = this.query_hash.sort_by.find((sort_by) => sort_by[field_name]);
+
+    // Since objects are references in Javascript, we can update the reference we found
+    // For example,
+    if (previously_sorted_obj) {
+      previously_sorted_obj[field_name] = dir;
+    } else {
+      this.query_hash.sort_by.push(sort_bucket);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
### Brief Summary of Changes
Prevents duplicate fields in search API for various fields:
sort_by, aggregate and with_field

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

