### PR TITLE
Prevent preview:duration from being normalized

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -226,7 +226,7 @@ exports.create_slideshow = function create_slideshow(options, callback) {
     // Generate a transformation from the manifest_transformation key, which should be a valid transformation
     var manifest_transformation = utils.generate_transformation_string(extend({}, options.manifest_transformation));
 
-    // Try to use all the options to generate a transformation (Example: options.width and options.height)
+    // Try to use {options.transformation} to generate a transformation (Example: options.transformation.width, options.transformation.height)
     var transformation = utils.generate_transformation_string(extend({}, ensureOption(options, 'transformation', {})));
 
     return [{

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -159,7 +159,14 @@ function normalize_expression(expression) {
     return CONDITIONAL_OPERATORS[match];
   });
 
-  var predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  // Duplicate PREDEFINED_VARS to also include :{var_name} as well as {var_name}
+  // Example:
+  // -- PREDEFINED_VARS = ['foo']
+  // -- predefinedVarsPattern = ':foo|foo'
+  // It is done like this because node 6 does not support regex lookbehind
+  var predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).map(function (v) {
+    return `:${v}|${v}`;
+  }).join("|") + ")";
   var userVariablePattern = '(\\$_*[^_ ]+)';
   var variablesReplaceRE = new RegExp(`${userVariablePattern}|${predefinedVarsPattern}`, "g");
   expression = expression.replace(variablesReplaceRE, function (match) {
@@ -1643,6 +1650,7 @@ exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;
 exports.DEFAULT_VIDEO_SOURCE_TYPES = DEFAULT_VIDEO_SOURCE_TYPES;
 
 Object.assign(module.exports, {
+  normalize_expression,
   at,
   clone,
   extend,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -144,7 +144,12 @@ function normalize_expression(expression) {
   const operatorsReplaceRE = new RegExp(operatorsPattern, "g");
   expression = expression.replace(operatorsReplaceRE, match => CONDITIONAL_OPERATORS[match]);
 
-  const predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).join("|") + ")";
+  // Duplicate PREDEFINED_VARS to also include :{var_name} as well as {var_name}
+  // Example:
+  // -- PREDEFINED_VARS = ['foo']
+  // -- predefinedVarsPattern = ':foo|foo'
+  // It is done like this because node 6 does not support regex lookbehind
+  const predefinedVarsPattern = "(" + Object.keys(PREDEFINED_VARS).map(v => `:${v}|${v}`).join("|") + ")";
   const userVariablePattern = '(\\$_*[^_ ]+)';
   const variablesReplaceRE = new RegExp(`${userVariablePattern}|${predefinedVarsPattern}`, "g");
   expression = expression.replace(variablesReplaceRE, (match) => (PREDEFINED_VARS[match] || match));
@@ -1509,6 +1514,7 @@ exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;
 exports.DEFAULT_VIDEO_SOURCE_TYPES = DEFAULT_VIDEO_SOURCE_TYPES;
 
 Object.assign(module.exports, {
+  normalize_expression,
   at,
   clone,
   extend,

--- a/test/unit/normalize_expression_spec.js
+++ b/test/unit/normalize_expression_spec.js
@@ -1,0 +1,57 @@
+const cloudinary = require("../../cloudinary");
+const createTestConfig = require('../testUtils/createTestConfig');
+
+describe("normalize_expression tests", function () {
+  beforeEach(function () {
+    cloudinary.config(createTestConfig({
+      cloud_name: "test123",
+      api_key: 'a',
+      api_secret: 'b'
+    }));
+  });
+
+  it("Expression normalization", function() {
+    const cases = {
+      'null is not affected': [null, null],
+      'None is not affected': ['None', 'None'],
+      'empty string is not affected': ['', ''],
+      'single space is replaced with a single underscore': [' ', '_'],
+      'blank string is replaced with a single underscore': ['   ', '_'],
+      'underscore is not affected': ['_', '_'],
+      'sequence of underscores and spaces is replaced with a single underscore': [' _ __  _', '_'],
+      'arbitrary text is not affected': ['foobar', 'foobar'],
+      'double ampersand replaced with and operator': ['foo && bar', 'foo_and_bar'],
+      'double ampersand with no space at the end is not affected': ['foo&&bar', 'foo&&bar'],
+      'width recognized as variable and replaced with w': ['width', 'w'],
+      'initial aspect ratio recognized as variable and replaced with iar': ['initial_aspect_ratio', 'iar'],
+      'duration is recognized as a variable and replaced with du': ['duration', 'du'],
+      'duration after : is not a variable and is not affected': ['preview:duration_2', 'preview:duration_2'],
+      '$width recognized as user variable and not affected': ['$width', '$width'],
+      '$initial_aspect_ratio recognized as user variable followed by aspect_ratio variable': [
+        '$initial_aspect_ratio',
+        '$initial_ar'
+      ],
+      '$mywidth recognized as user variable and not affected': ['$mywidth', '$mywidth'],
+      '$widthwidth recognized as user variable and not affected': ['$widthwidth', '$widthwidth'],
+      '$_width recognized as user variable and not affected': ['$_width', '$_width'],
+      '$__width recognized as user variable and not affected': ['$__width', '$_width'],
+      '$$width recognized as user variable and not affected': ['$$width', '$$width'],
+      '$height recognized as user variable and not affected': ['$height_100', '$height_100'],
+      '$heightt_100 recognized as user variable and not affected': ['$heightt_100', '$heightt_100'],
+      '$$height_100 recognized as user variable and not affected': ['$$height_100', '$$height_100'],
+      '$heightmy_100 recognized as user variable and not affected': ['$heightmy_100', '$heightmy_100'],
+      '$myheight_100 recognized as user variable and not affected': ['$myheight_100', '$myheight_100'],
+      '$heightheight_100 recognized as user variable and not affected': [
+        '$heightheight_100',
+        '$heightheight_100'
+      ],
+      '$theheight_100 recognized as user variable and not affected': ['$theheight_100', '$theheight_100'],
+      '$__height_100 recognized as user variable and not affected': ['$__height_100', '$_height_100']
+    };
+
+    Object.keys(cases).forEach(function (testDescription) {
+      const [input, expected] = cases[testDescription];
+      expect(cloudinary.utils.normalize_expression(input)).to.equal(expected);
+    });
+  });
+});


### PR DESCRIPTION
### Brief Summary of Changes
Prevent the duration param in e_preview from being normalized

### Note
Do not review the es5 files, as those are build files.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No
