### PR TITLE
fix: `verifyNotificationSignature` timestamps are in seconds

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1093,7 +1093,7 @@ function webhook_signature(data, timestamp) {
  * Verifies the authenticity of a notification signature
  *
  * @param {string} body JSON of the request's body
- * @param {number} timestamp Unix timestamp. Can be retrieved from the X-Cld-Timestamp header
+ * @param {number} timestamp Unix timestamp in seconds. Can be retrieved from the X-Cld-Timestamp header
  * @param {string} signature Actual signature. Can be retrieved from the X-Cld-Signature header
  * @param {number} [valid_for=7200] The desired time in seconds for considering the request valid
  *
@@ -1103,7 +1103,7 @@ function verifyNotificationSignature(body, timestamp, signature) {
   var valid_for = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 7200;
 
   // verify that signature is valid for the given timestamp
-  if (timestamp < Date.now() - valid_for) {
+  if (timestamp < Math.round(Date.now() / 1000) - valid_for) {
     return false;
   }
   var payload_hash = utils.webhook_signature(body, timestamp, {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1004,7 +1004,7 @@ function webhook_signature(data, timestamp, options = {}) {
  * Verifies the authenticity of a notification signature
  *
  * @param {string} body JSON of the request's body
- * @param {number} timestamp Unix timestamp. Can be retrieved from the X-Cld-Timestamp header
+ * @param {number} timestamp Unix timestamp in seconds. Can be retrieved from the X-Cld-Timestamp header
  * @param {string} signature Actual signature. Can be retrieved from the X-Cld-Signature header
  * @param {number} [valid_for=7200] The desired time in seconds for considering the request valid
  *
@@ -1012,7 +1012,7 @@ function webhook_signature(data, timestamp, options = {}) {
  */
 function verifyNotificationSignature(body, timestamp, signature, valid_for = 7200) {
   // verify that signature is valid for the given timestamp
-  if (timestamp < Date.now() - valid_for) {
+  if (timestamp < Math.round(Date.now() / 1000) - valid_for) {
     return false;
   }
   const payload_hash = utils.webhook_signature(body, timestamp, {

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -1459,8 +1459,8 @@ describe("utils", function () {
         'width': 100,
         'height': 100
       };
-      valid_response_timestamp = Date.now() - 5000;
-      invalid_response_timestamp = Date.now() - 50 * 1000;
+      valid_response_timestamp = (Date.now()/1000) - 5000;
+      invalid_response_timestamp = (Date.now()/1000) - 10000;
       response_json = JSON.stringify(expected_parameters);
       unexpected_response_json = JSON.stringify(unexpected_parameters);
     });


### PR DESCRIPTION
### Brief Summary of Changes
As described here https://cloudinary.com/documentation/notifications#notification_payload Cloudinary sends notification payloads with a `X-Cld-Timestamp` and `X-Cld-Signature` headers

 - The timestamp is in a seconds, but the signature verification assumes the timestamp is in milliseconds 
 - The `valid_for` parameter is also in seconds, and `Date.now()` returns milliseconds, which causes the calculation to be off.

#### What Does This PR Address?
- [x] Bug fix

#### Are Tests Included?
- [x] No

#### Reviewer, Please Note:
To verify reviewer needs to set the `notificaiton_url` upload an asset and verify that the given timestamp in the header is in seconds.

on the notification handler code verify the signature with the following code
```js
await cloudinary.utils.verifyNotificationSignature(
    JSON.stringify(req.body),
    req.headers['x-cld-timestamp'],
    req.headers['x-cld-signature'])
```

You would notice the timestamp check currently fails but works fine on after this fix.