### PR TITLE
Add proxy support

### DIFF
--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -8,9 +8,11 @@ var Q = require('q');
 var url = require('url');
 var utils = require("../utils");
 var ensureOption = require('../utils/ensureOption').defaults(config());
+var ProxyAgent = utils.optionalRequire('proxy-agent');
 
 var extend = utils.extend,
-    includes = utils.includes;
+    includes = utils.includes,
+    isEmpty = utils.isEmpty;
 
 
 function execute_request(method, params, auth, api_url, callback) {
@@ -55,6 +57,18 @@ function execute_request(method, params, auth, api_url, callback) {
 
   if (options.agent != null) {
     request_options.agent = options.agent;
+  }
+
+  var proxy = options.api_proxy || config().api_proxy;
+  if (!isEmpty(proxy)) {
+    if (!request_options.agent) {
+      if (ProxyAgent === null) {
+        throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");
+      }
+      request_options.agent = new ProxyAgent(proxy);
+    } else {
+      console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
+    }
   }
   if (method !== "GET") {
     request_options.headers['Content-Length'] = Buffer.byteLength(query_params);

--- a/lib-es5/config.js
+++ b/lib-es5/config.js
@@ -15,6 +15,7 @@ var extend = require("lodash/extend");
 var isObject = require("lodash/isObject");
 var isString = require("lodash/isString");
 var isUndefined = require("lodash/isUndefined");
+var isEmpty = require("lodash/isEmpty");
 var entries = require('./utils/entries');
 
 var cloudinary_config = void 0;
@@ -117,12 +118,16 @@ module.exports = function (new_config, new_value) {
 
     var CLOUDINARY_ENV_URL = process.env.CLOUDINARY_URL;
     var CLOUDINARY_ENV_ACCOUNT_URL = process.env.CLOUDINARY_ACCOUNT_URL;
+    var CLOUDINARY_API_PROXY = process.env.CLOUDINARY_API_PROXY;
 
     if (CLOUDINARY_ENV_URL && !CLOUDINARY_ENV_URL.toLowerCase().startsWith('cloudinary://')) {
       throw new Error("Invalid CLOUDINARY_URL protocol. URL should begin with 'cloudinary://'");
     }
     if (CLOUDINARY_ENV_ACCOUNT_URL && !CLOUDINARY_ENV_ACCOUNT_URL.toLowerCase().startsWith('account://')) {
       throw new Error("Invalid CLOUDINARY_ACCOUNT_URL protocol. URL should begin with 'account://'");
+    }
+    if (!isEmpty(CLOUDINARY_API_PROXY)) {
+      extendCloudinaryConfig({ api_proxy: CLOUDINARY_API_PROXY }, cloudinary_config);
     }
 
     [CLOUDINARY_ENV_URL, CLOUDINARY_ENV_ACCOUNT_URL].forEach(function (ENV_URL) {

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1633,6 +1633,19 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
+function optionalRequire(moduleName) {
+  var module = void 0;
+  try {
+    module = require(moduleName);
+    return module;
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw e;
+  }
+}
+
 /**
  * Empty function - do nothing
  *
@@ -1690,6 +1703,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.optionalRequire = optionalRequire;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -6,8 +6,9 @@ const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
+const ProxyAgent = utils.optionalRequire('proxy-agent');
 
-const { extend, includes } = utils;
+const { extend, includes, isEmpty } = utils;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
@@ -48,6 +49,18 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
 
   if (options.agent != null) {
     request_options.agent = options.agent;
+  }
+
+  let proxy = options.api_proxy || config().api_proxy;
+  if (!isEmpty(proxy)) {
+    if (!request_options.agent) {
+      if (ProxyAgent === null) {
+        throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
+      }
+      request_options.agent = new ProxyAgent(proxy);
+    } else {
+      console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
+    }
   }
   if (method !== "GET") {
     request_options.headers['Content-Length'] = Buffer.byteLength(query_params);

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ const extend = require("lodash/extend");
 const isObject = require("lodash/isObject");
 const isString = require("lodash/isString");
 const isUndefined = require("lodash/isUndefined");
+const isEmpty = require("lodash/isEmpty");
 const entries = require('./utils/entries');
 
 let cloudinary_config = void 0;
@@ -95,12 +96,16 @@ module.exports = function (new_config, new_value) {
 
     let CLOUDINARY_ENV_URL = process.env.CLOUDINARY_URL;
     let CLOUDINARY_ENV_ACCOUNT_URL = process.env.CLOUDINARY_ACCOUNT_URL;
-    
+    let CLOUDINARY_API_PROXY = process.env.CLOUDINARY_API_PROXY;
+
     if (CLOUDINARY_ENV_URL && !CLOUDINARY_ENV_URL.toLowerCase().startsWith('cloudinary://')) {
       throw new Error("Invalid CLOUDINARY_URL protocol. URL should begin with 'cloudinary://'");
     }
     if (CLOUDINARY_ENV_ACCOUNT_URL && !CLOUDINARY_ENV_ACCOUNT_URL.toLowerCase().startsWith('account://')) {
       throw new Error("Invalid CLOUDINARY_ACCOUNT_URL protocol. URL should begin with 'account://'");
+    }
+    if (!isEmpty(CLOUDINARY_API_PROXY)) {
+      extendCloudinaryConfig({ api_proxy: CLOUDINARY_API_PROXY }, cloudinary_config);
     }
 
     [CLOUDINARY_ENV_URL, CLOUDINARY_ENV_ACCOUNT_URL].forEach((ENV_URL) => {

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -14,12 +14,14 @@ const Cache = require('./cache');
 const utils = require("./utils");
 const UploadStream = require('./upload_stream');
 const config = require("./config");
+const ProxyAgent = utils.optionalRequire('proxy-agent');
 const ensureOption = require('./utils/ensureOption').defaults(config());
 
 const {
   build_upload_params,
   extend,
   includes,
+  isEmpty,
   isObject,
   isRemoteUrl,
   merge,
@@ -569,6 +571,18 @@ function post(url, post_data, boundary, file, callback, options) {
   if (options.agent != null) {
     post_options.agent = options.agent;
   }
+  let proxy = options.api_proxy || config().api_proxy;
+  if (!isEmpty(proxy)) {
+    if (!post_options.agent) {
+      if (ProxyAgent === null) {
+        throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
+      }
+      post_options.agent = new ProxyAgent(proxy);
+    } else {
+      console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
+    }
+  }
+
   let post_request = https.request(post_options, callback);
   let upload_stream = new UploadStream({ boundary });
   upload_stream.pipe(post_request);

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1499,6 +1499,19 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
+function optionalRequire(moduleName) {
+  let module;
+  try {
+    module = require(moduleName)
+    return module;
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw e;
+  }
+}
+
 /**
  * Empty function - do nothing
  *
@@ -1554,6 +1567,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.optionalRequire = optionalRequire;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "test-es5": "tools/scripts/test.es5.sh",
     "docs": "tools/scripts/docs.sh"
   },
-  "optionalDependencies": {},
+  "optionalDependencies": {
+    "proxy-agent": "^4.0.1"
+  },
   "engines": {
     "node": ">=0.6"
   }

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -5,14 +5,18 @@ const cloudinary = require("../../cloudinary");
 describe("config", function () {
   let cloudinaryUrlBackup;
   let accountUrlBackup;
+  let proxyBackup;
+
   before(function () {
     cloudinaryUrlBackup = process.env.CLOUDINARY_URL;
     accountUrlBackup = process.env.CLOUDINARY_ACCOUNT_URL;
+    proxyBackup = process.env.CLOUDINARY_API_PROXY;
   });
 
   after(function () {
     process.env.CLOUDINARY_URL = cloudinaryUrlBackup || '';
     process.env.CLOUDINARY_ACCOUNT_URL = accountUrlBackup || '';
+    process.env.CLOUDINARY_API_PROXY = proxyBackup || '';
     cloudinary.config(true);
   });
 
@@ -79,5 +83,18 @@ describe("config", function () {
   it("should not throw an error when CLOUDINARY_ACCOUNT_URL environment variable is missing", function () {
     delete process.env.CLOUDINARY_ACCOUNT_URL;
     cloudinary.config(true);
+  });
+
+  it("should support CLOUDINARY_API_PROXY environment variable", function () {
+    const proxy = "https://myuser:mypass@example.com"
+    process.env.CLOUDINARY_API_PROXY = proxy;
+    const config = cloudinary.config(true);
+    expect(config.api_proxy).to.eql(proxy)
+  });
+
+  it("should support `api_proxy` config param", function () {
+    const proxy = "https://myuser:mypass@example.com"
+    const config = cloudinary.config({api_proxy: proxy});
+    expect(config.api_proxy).to.eql(proxy)
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -327,6 +327,7 @@ declare module 'cloudinary' {
         cloud_name?: string;
         api_key?: string;
         api_secret?: string;
+        api_proxy?: string;
         private_cdn?: boolean;
         secure_distribution?: string;
         force_version?: boolean;


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
- proxy-agent is added as an optional dependency. This way devs who want smaller package and don't need proxy support can use `npm install --no-optional`
- proxy-agent version is 4.x since in 5.x branch it drops node v6 support