### PR TITLE
Bump proxy-agent version to ^5.0.0 due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "docs": "tools/scripts/docs.sh"
   },
   "optionalDependencies": {
-    "proxy-agent": "^4.0.1"
+    "proxy-agent": "^5.0.0"
   },
   "engines": {
     "node": ">=0.6"


### PR DESCRIPTION
Notice that proxy-agent 5.0.0 drops support for node v6, see here:
https://github.com/TooTallNate/node-proxy-agent/releases/tag/5.0.0