### PR TITLE
Stabilize metadata tests

### DIFF
--- a/test/testUtils/helpers/retry.js
+++ b/test/testUtils/helpers/retry.js
@@ -1,0 +1,29 @@
+const { RETRY } = require('../testConstants');
+const wait = require('./wait')
+
+/**
+ * Creates a proxy to retry the function call until it succeeds.
+ * Custom retry function is used to be able to retry only assert-related
+ * code segments of the tests and use delays between retries.
+ *
+ * @param {function} fn The function to retry.
+ * @param {number} [limit=3] The number of attempts.
+ * @param {number} [delay=1000] The delay between attempts, ms.
+ *
+ * @returns {function}
+ */
+module.exports = async function retry(fn, limit = RETRY.LIMIT, delay= RETRY.DELAY) {
+  while (limit--) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await fn();
+    } catch (e) {
+      if (!limit) {
+        throw e;
+      }
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await wait(delay)
+  }
+}

--- a/test/testUtils/testConstants.js
+++ b/test/testUtils/testConstants.js
@@ -31,6 +31,10 @@ module.exports = {
     LONG: 50000,
     LARGE: 70000
   },
+  RETRY: {
+    LIMIT: 3,
+    DELAY: 1000
+  },
   UNIQUE_JOB_SUFFIX_ID,
   PUBLIC_IDS: {
     PUBLIC_ID,


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
Some details about changes:

- Q.all instead of Q.allSettled in before, since there is no reason to continue tests if setup failed
- metadata creation as a separate call before uploading to avoid potential race conditions
- retry of test fragments instead of entire tests - to be able to reuse the same approach in tests which upload files as part of the test.