### PR TITLE
Updating hyperlink under "Note" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Effortlessly optimize, transform, upload and manage your cloud's assets.
 
 #### Note
 This Readme provides basic installation and usage information. 
-For the complete documentation, see the [Node SDK Guide](https://cloudinary.com/documentation/node_integrations).
+For the complete documentation, see the [Node SDK Guide](https://cloudinary.com/documentation/node_integration).
 
 ## Table of Contents
 - [Key Features](#key-features)


### PR DESCRIPTION
Per https://github.com/cloudinary/cloudinary_npm/issues/536 updating hyperlink to the correct page, current link does not exist.

### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
