### PR TITLE
Add `filename_override` option to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -492,6 +492,7 @@ declare module 'cloudinary' {
         eval?: string;
         exif?: boolean;
         faces?: boolean;
+        filename_override?: string;
         folder?: string;
         format?: VideoFormat | ImageFormat;
         image_metadata?: boolean;


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

Add the `filename_override` optional option to the types

Ref (docs): https://cloudinary.com/documentation/image_upload_api_reference#:~:text=true.%20Default%3A%20true.-,filename_override,-String

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

This feature was implemented in the client in #471 by @strausr (without an update to the types)

cc @patrick-tolosa