### PR TITLE
Add colors type to upload response, fix type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -591,6 +591,7 @@ declare module 'cloudinary' {
         access_control: Array<string>;
         context: object;
         metadata: object;
+        colors?: [`#${string}`, number][];
 
         [futureKey: string]: any;
     }
@@ -668,7 +669,7 @@ declare module 'cloudinary' {
                 image_metadata: object;
                 faces: number[][];
                 quality_analysis: number;
-                colors: string[][];
+                colors: [`#${string}`, number][];
                 derived: Array<string>;
                 moderation: object;
                 phash: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -669,7 +669,7 @@ declare module 'cloudinary' {
                 image_metadata: object;
                 faces: number[][];
                 quality_analysis: number;
-                colors: [`#${string}`, number][];
+                colors: [string, number][];
                 derived: Array<string>;
                 moderation: object;
                 phash: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -591,7 +591,7 @@ declare module 'cloudinary' {
         access_control: Array<string>;
         context: object;
         metadata: object;
-        colors?: [`#${string}`, number][];
+        colors?: [string, number][];
 
         [futureKey: string]: any;
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

- Add a missing optional `colors` key to the `UploadApiResponse` type
- Fix the type on the `ResourceResponseType`, as per [the docs](https://cloudinary.com/documentation/analysis_on_upload#semantic_data_extraction)

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

If you would prefer the type `string` instead of using [TypeScript template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) (released in TS 4.1) then I can make this change.

cc @patrick-tolosa 