### PR TITLE
Bump lodash version to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "cloudinary-core": "^2.10.2",
     "core-js": "3.6.5",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.21",
     "q": "^1.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Brief Summary of Changes
Bump lodash version to 4.17.21 due to vulnerabilities: https://snyk.io/vuln/npm:lodash

#### What Does This PR Address?
- [X] GitHub issue #550 
