### PR TITLE
Add dynamic folder feature

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -104,6 +104,17 @@ exports.resource_by_asset_id = function resource_by_asset_id(asset_id, callback)
   return call_api("get", uri, getResourceParams(options), callback, options);
 };
 
+exports.resources_by_asset_folder = function resources_by_asset_folder(asset_folder, callback) {
+  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+  var params = void 0,
+      uri = void 0;
+  uri = ["resources", 'by_asset_folder'];
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "moderations");
+  params.asset_folder = asset_folder;
+  return call_api("get", uri, params, callback, options);
+};
+
 exports.resources_by_asset_ids = function resources_by_asset_ids(asset_ids, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -386,7 +386,8 @@ function build_upload_params(options) {
     use_filename: utils.as_safe_bool(options.use_filename),
     use_filename_as_display_name: utils.as_safe_bool(options.use_filename_as_display_name),
     quality_override: options.quality_override,
-    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis)
+    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis),
+    use_asset_folder_as_public_id_prefix: utils.as_safe_bool(options.use_asset_folder_as_public_id_prefix)
   };
   return utils.updateable_resource_params(options, params);
 }
@@ -725,6 +726,15 @@ function updateable_resource_params(options) {
   }
   if (options.quality_override != null) {
     params.quality_override = options.quality_override;
+  }
+  if (options.asset_folder != null) {
+    params.asset_folder = options.asset_folder;
+  }
+  if (options.display_name != null) {
+    params.display_name = options.display_name;
+  }
+  if (options.unique_display_name != null) {
+    params.unique_display_name = options.unique_display_name;
   }
   return params;
 }

--- a/lib-es5/v2/api.js
+++ b/lib-es5/v2/api.js
@@ -14,6 +14,7 @@ v1_adapters(exports, api, {
   resource_by_asset_id: 1,
   resources_by_asset_ids: 1,
   resources_by_ids: 1,
+  resources_by_asset_folder: 1,
   resource: 1,
   restore: 1,
   update: 1,

--- a/lib/api.js
+++ b/lib/api.js
@@ -76,6 +76,14 @@ exports.resource_by_asset_id = function resource_by_asset_id(asset_id, callback,
   return call_api("get", uri, getResourceParams(options), callback, options);
 }
 
+exports.resources_by_asset_folder = function resources_by_asset_folder(asset_folder, callback, options = {}) {
+  let params, uri;
+  uri = ["resources", 'by_asset_folder'];
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "moderations");
+  params.asset_folder = asset_folder;
+  return call_api("get", uri, params, callback, options);
+};
+
 exports.resources_by_asset_ids = function resources_by_asset_ids(asset_ids, callback, options = {}) {
   let params, uri;
   uri = ["resources", "by_asset_ids"];

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -365,7 +365,8 @@ function build_upload_params(options) {
     use_filename: utils.as_safe_bool(options.use_filename),
     use_filename_as_display_name: utils.as_safe_bool(options.use_filename_as_display_name),
     quality_override: options.quality_override,
-    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis)
+    accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis),
+    use_asset_folder_as_public_id_prefix: utils.as_safe_bool(options.use_asset_folder_as_public_id_prefix)
   };
   return utils.updateable_resource_params(options, params);
 }
@@ -643,6 +644,15 @@ function updateable_resource_params(options, params = {}) {
   }
   if (options.quality_override != null) {
     params.quality_override = options.quality_override;
+  }
+  if (options.asset_folder != null){
+    params.asset_folder = options.asset_folder;
+  }
+  if (options.display_name != null){
+    params.display_name = options.display_name;
+  }
+  if (options.unique_display_name != null){
+    params.unique_display_name = options.unique_display_name;
   }
   return params;
 }

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -12,6 +12,7 @@ v1_adapters(exports, api, {
   resource_by_asset_id: 1,
   resources_by_asset_ids: 1,
   resources_by_ids: 1,
+  resources_by_asset_folder: 1,
   resource: 1,
   restore: 1,
   update: 1,

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -30,6 +30,7 @@ const METADATA_SAMPLE_DATA_ENCODED = "metadata_color=red|metadata_shape=dodecahe
 const createTestConfig = require('../../../testUtils/createTestConfig');
 
 const testConstants = require('../../../testUtils/testConstants');
+const {shouldTestFeature, DYNAMIC_FOLDERS} = require("../../../spechelper");
 const UPLOADER_V2 = cloudinary.v2.uploader;
 
 const {
@@ -773,9 +774,9 @@ describe("uploader", function () {
       });
     });
   });
-  describe("folder decoupling", () => {
+  describe("dynamic folders", () => {
     const mocked = helper.mockTest();
-    it('should pass folder decoupling params', () => {
+    it('should pass dynamic folder params', () => {
       const public_id_prefix = "fd_public_id_prefix";
       const asset_folder = "asset_folder";
       const display_name = "display_name";
@@ -793,6 +794,47 @@ describe("uploader", function () {
       sinon.assert.calledWithMatch(mocked.write, helper.uploadParamMatcher("display_name", display_name));
       sinon.assert.calledWithMatch(mocked.write, helper.uploadParamMatcher("use_filename_as_display_name", 1));
       sinon.assert.calledWithMatch(mocked.write, helper.uploadParamMatcher("folder", folder));
+    });
+
+    it('should not contain asset_folder in public_id', async function () {
+      if (!shouldTestFeature(DYNAMIC_FOLDERS)) {
+        this.skip();
+      }
+
+      const asset_folder = "asset_folder";
+      return UPLOADER_V2.upload(IMAGE_FILE, {
+        asset_folder
+      }).then((result) => {
+        expect(result.public_id).to.not.contain('asset_folder')
+      });
+    });
+
+    it('should not contain asset_folder in public_id when use_asset_folder_as_public_id_prefix is false', async function () {
+      if (!shouldTestFeature(DYNAMIC_FOLDERS)) {
+        this.skip();
+      }
+
+      const asset_folder = "asset_folder";
+      return UPLOADER_V2.upload(IMAGE_FILE, {
+        asset_folder,
+        use_asset_folder_as_public_id_prefix: false
+      }).then((result) => {
+        expect(result.public_id).to.not.contain('asset_folder')
+      });
+    });
+
+    it('should contain asset_folder in public_id when use_asset_folder_as_public_id_prefix is true', async function () {
+      if (!shouldTestFeature(DYNAMIC_FOLDERS)) {
+        this.skip();
+      }
+
+      const asset_folder = "asset_folder";
+      return UPLOADER_V2.upload(IMAGE_FILE, {
+        asset_folder,
+        use_asset_folder_as_public_id_prefix: true
+      }).then((result) => {
+        expect(result.public_id).to.contain('asset_folder')
+      });
     });
   });
   it("should support unsigned uploading using presets", async function () {

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -27,7 +27,7 @@ exports.ICON_FILE = "test/.resources/favicon.ico";
 exports.VIDEO_URL = "http://res.cloudinary.com/demo/video/upload/dog.mp4";
 exports.IMAGE_URL = "http://res.cloudinary.com/demo/image/upload/sample";
 
-exports.ADDON_ALL = 'all'; // Test all addons.
+const ADDON_ALL = 'all'; // Test all addons.
 exports.ADDON_ASPOSE = 'aspose'; // Aspose document conversion.
 exports.ADDON_AZURE = 'azure'; // Microsoft azure video indexer.
 exports.ADDON_BG_REMOVAL = 'bgremoval'; // Cloudinary AI background removal.
@@ -53,6 +53,8 @@ exports.ADDON_URL2PNG = 'url2png'; // URL2PNG website screenshots.
 exports.ADDON_VIESUS = 'viesus'; // VIESUS automatic image enhancement.
 exports.ADDON_WEBPURIFY = 'webpurify'; // WebPurify image moderation.
 exports.DYNAMIC_FOLDERS = 'dynamic_folders'
+
+const ALL = 'all';
 
 const { TEST_TAG } = require('./testUtils/testConstants').TAGS;
 
@@ -293,8 +295,9 @@ exports.toISO8601DateOnly = function (timestamp) {
  * @returns {boolean}
  */
 exports.shouldTestAddOn = function (addOn) {
+  
   const cldTestAddons = (process.env.CLD_TEST_ADDONS || '').toLowerCase();
-  if (cldTestAddons === this.ADDON_ALL) {
+  if (cldTestAddons === ADDON_ALL) {
     return true;
   }
   return cldTestAddons.trim().split(',').includes(addOn.toLowerCase())
@@ -308,7 +311,11 @@ exports.shouldTestAddOn = function (addOn) {
  * @return boolean
  */
 exports.shouldTestFeature = function(feature){
-  return feature === 'ALL';
+  const cldTestFeatures = (process.env.CLD_TEST_FEATURES || '').toLowerCase();
+  if (cldTestFeatures === ALL) {
+    return true;
+  }
+  return cldTestFeatures.trim().split(',').includes(feature.toLowerCase())
 }
 
 

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -295,7 +295,6 @@ exports.toISO8601DateOnly = function (timestamp) {
  * @returns {boolean}
  */
 exports.shouldTestAddOn = function (addOn) {
-  
   const cldTestAddons = (process.env.CLD_TEST_ADDONS || '').toLowerCase();
   if (cldTestAddons === ADDON_ALL) {
     return true;

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -52,6 +52,7 @@ exports.ADDON_REKOGNITION = 'rekognition'; /* Amazon rekognition AI moderation,
 exports.ADDON_URL2PNG = 'url2png'; // URL2PNG website screenshots.
 exports.ADDON_VIESUS = 'viesus'; // VIESUS automatic image enhancement.
 exports.ADDON_WEBPURIFY = 'webpurify'; // WebPurify image moderation.
+exports.DYNAMIC_FOLDERS = 'dynamic_folders'
 
 const { TEST_TAG } = require('./testUtils/testConstants').TAGS;
 
@@ -297,6 +298,17 @@ exports.shouldTestAddOn = function (addOn) {
     return true;
   }
   return cldTestAddons.trim().split(',').includes(addOn.toLowerCase())
+}
+
+/**
+ * Should a certain feature be tested?
+ *
+ * @param {string} feature The feature to test.
+ *
+ * @return boolean
+ */
+exports.shouldTestFeature = function(feature){
+  return feature === 'ALL';
 }
 
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -438,6 +438,9 @@ declare module 'cloudinary' {
         moderation_status?: string;
         unsafe_update?: object;
         allowed_for_strict?: boolean;
+        asset_folder?: string;
+        unique_display_name?: boolean;
+        display_name?: string
 
         [futureKey: string]: any;
     }
@@ -515,6 +518,7 @@ declare module 'cloudinary' {
         chunk_size?: number;
         disable_promises?: boolean;
         oauth_token?: string;
+        use_asset_folder_as_public_id_prefix?: boolean;
 
         [futureKey: string]: any;
     }
@@ -843,6 +847,10 @@ declare module 'cloudinary' {
             function resources_by_ids(public_ids: string[] | string, options?: AdminAndResourceOptions, callback?: ResponseCallback): Promise<ResourceApiResponse>;
 
             function resources_by_ids(public_ids: string[] | string, callback?: ResponseCallback): Promise<ResourceApiResponse>;
+
+            function resources_by_asset_folder(asset_folder: string, options?: AdminAndResourceOptions, callback?: ResponseCallback): Promise<ResourceApiResponse>;
+
+            function resources_by_asset_folder(asset_folder: string, callback?: ResponseCallback): Promise<ResourceApiResponse>;
 
             function resources_by_moderation(moderation: ModerationKind, status: Status, options?: AdminAndResourceOptions, callback?: ResponseCallback): Promise<ResourceApiResponse>;
 


### PR DESCRIPTION
### Brief Summary of Changes
Add dynamic folder feature

This PR adds support for the new Admin API function resources_by_asset_folder.

In addition, it adds support for the following parameters:

- asset_folder
- unique_display_name
- use_asset_folder_as_public_id_prefix
- to the relevant admin and upload API functions.

Please note that the integration test for the new function was set with conditional flag, since by default this API is not available for all accounts.