### PR TITLE
Add type for generate_transformation_string

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -729,6 +729,8 @@ declare module 'cloudinary' {
 
             function video_url(public_id?: string, options?: VideoTransformationOptions | ConfigAndUrlOptions): string;
 
+            function generate_transformation_string(options: TransformationOptions): string;
+
             function archive_params(options?: ArchiveApiOptions): Promise<any>;
 
             function download_archive_url(options?: ArchiveApiOptions | ConfigAndUrlOptions): string


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

Add a type for the missing `utils.generate_transformation_string` function

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

cc @patrick-tolosa