### PR TITLE
Make types more strict

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,6 @@ declare module 'cloudinary' {
     /****************************** Constants *************************************/
     /****************************** Transformations *******************************/
     type CropMode =
-        string
         | "scale"
         | "fit"
         | "limit"
@@ -21,7 +20,6 @@ declare module 'cloudinary' {
         | "imagga_crop"
         | "imagga_scale";
     type Gravity =
-        string
         | "north_west"
         | "north"
         | "north_east"
@@ -61,7 +59,6 @@ declare module 'cloudinary' {
         | "ocr_text";
     type Angle = number | string | Array<number | string> | "auto_right" | "auto_left" | "ignore" | "vflip" | "hflip";
     type ImageEffect =
-        string
         | "hue"
         | "red"
         | "green"
@@ -166,7 +163,6 @@ declare module 'cloudinary' {
         | "tiff8_lzw"
         | "tiled";
     type VideoFlags =
-        string
         | Array<string>
         | "animated"
         | "awebp"
@@ -181,9 +177,8 @@ declare module 'cloudinary' {
         | "relative"
         | "truncate_ts"
         | "waveform";
-    type ColorSpace = string | "srgb" | "no_cmyk" | "keep_cmyk";
+    type ColorSpace = "srgb" | "no_cmyk" | "keep_cmyk";
     type DeliveryType =
-        string
         | "upload"
         | "private"
         | "authenticated"
@@ -204,9 +199,8 @@ declare module 'cloudinary' {
         | "worldstarhiphop"
         | "dailymotion";
     /****************************** URL *************************************/
-    type ResourceType = string | "image" | "raw" | "video";
+    type ResourceType = "image" | "raw" | "video";
     type ImageFormat =
-        string
         | "gif"
         | "png"
         | "jpg"
@@ -232,7 +226,6 @@ declare module 'cloudinary' {
         | "tga"
         | "heic"
     type VideoFormat =
-        string
         | "auto"
         | "flv"
         | "m3u8"
@@ -548,7 +541,6 @@ declare module 'cloudinary' {
         | string[]
         | VideoTransformationOptions
         | ImageTransformationOptions
-        | Object
         | Array<ImageTransformationOptions>
         | Array<VideoTransformationOptions>;
 
@@ -561,11 +553,11 @@ declare module 'cloudinary' {
     type AdminAndUpdateApiOptions = AdminApiOptions | UpdateApiOptions;
 
     /****************************** API *************************************/
-    type Status = string | "pending" | "approved" | "rejected";
-    type StreamingProfiles = string | "4k" | "full_hd" | "hd" | "sd" | "full_hd_wifi" | "full_hd_lean" | "hd_lean";
-    type ModerationKind = string | "manual" | "webpurify" | "aws_rek" | "metascan";
-    type AccessMode = string | "public" | "authenticated";
-    type TargetArchiveFormat = string | "zip" | "tgz";
+    type Status = "pending" | "approved" | "rejected";
+    type StreamingProfiles = "4k" | "full_hd" | "hd" | "sd" | "full_hd_wifi" | "full_hd_lean" | "hd_lean";
+    type ModerationKind = "manual" | "webpurify" | "aws_rek" | "metascan";
+    type AccessMode = "public" | "authenticated";
+    type TargetArchiveFormat = "zip" | "tgz";
 
     // err is kept for backwards compatibility, it currently will always be undefined
     type ResponseCallback = (err?: any, callResult?: any) => any;


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

Make types more strict, to disallow typos on common literal string option values. Without these changes, there is no type safety for correct option values to be used as transformation options.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

cc @patrick-tolosa