### PR TITLE
Support multiple ACLs for generate_auth_token()

### DIFF
--- a/lib-es5/auth_token.js
+++ b/lib-es5/auth_token.js
@@ -35,7 +35,7 @@ function escapeToLower(url) {
  * @property {number} start_time=now The start time of the token in seconds from epoch.
  * @property {string} expiration The expiration time of the token in seconds from epoch.
  * @property {string} duration The duration of the token (from start_time).
- * @property {string} acl The ACL for the token.
+ * @property {string|Array.} acl The ACL for the token.
  * @property {string} url The URL to authentication in case of a URL token.
  *
  */
@@ -66,6 +66,9 @@ module.exports = function (options) {
   tokenParts.push(`exp=${options.expiration}`);
   if (options.acl != null) {
     tokenParts.push(`acl=${escapeToLower(options.acl)}`);
+  }
+  if (Array.isArray(options.acl) === true) {
+    options.acl = options.acl.join("!");
   }
   var toSign = [].concat(tokenParts);
   if (options.url != null && options.acl == null) {

--- a/lib-es5/auth_token.js
+++ b/lib-es5/auth_token.js
@@ -65,10 +65,10 @@ module.exports = function (options) {
   }
   tokenParts.push(`exp=${options.expiration}`);
   if (options.acl != null) {
+    if (Array.isArray(options.acl) === true) {
+      options.acl = options.acl.join("!");
+    }
     tokenParts.push(`acl=${escapeToLower(options.acl)}`);
-  }
-  if (Array.isArray(options.acl) === true) {
-    options.acl = options.acl.join("!");
   }
   var toSign = [].concat(tokenParts);
   if (options.url != null && options.acl == null) {

--- a/lib-es5/auth_token.js
+++ b/lib-es5/auth_token.js
@@ -35,7 +35,7 @@ function escapeToLower(url) {
  * @property {number} start_time=now The start time of the token in seconds from epoch.
  * @property {string} expiration The expiration time of the token in seconds from epoch.
  * @property {string} duration The duration of the token (from start_time).
- * @property {string|Array.} acl The ACL for the token.
+ * @property {string|Array<string>} acl The ACL(s) for the token.
  * @property {string} url The URL to authentication in case of a URL token.
  *
  */

--- a/lib/auth_token.js
+++ b/lib/auth_token.js
@@ -33,7 +33,7 @@ function escapeToLower(url) {
  * @property {number} start_time=now The start time of the token in seconds from epoch.
  * @property {string} expiration The expiration time of the token in seconds from epoch.
  * @property {string} duration The duration of the token (from start_time).
- * @property {string} acl The ACL for the token.
+ * @property {string|Array.} acl The ACL for the token.
  * @property {string} url The URL to authentication in case of a URL token.
  *
  */
@@ -60,6 +60,9 @@ module.exports = function (options) {
   }
   if (options.start_time != null) {
     tokenParts.push(`st=${options.start_time}`);
+  }
+  if (Array.isArray(options.acl) === true) {
+    options.acl = options.acl.join("!");
   }
   tokenParts.push(`exp=${options.expiration}`);
   if (options.acl != null) {

--- a/lib/auth_token.js
+++ b/lib/auth_token.js
@@ -33,7 +33,7 @@ function escapeToLower(url) {
  * @property {number} start_time=now The start time of the token in seconds from epoch.
  * @property {string} expiration The expiration time of the token in seconds from epoch.
  * @property {string} duration The duration of the token (from start_time).
- * @property {string|Array.} acl The ACL for the token.
+ * @property {string|Array<string>} acl The ACL(s) for the token.
  * @property {string} url The URL to authentication in case of a URL token.
  *
  */

--- a/lib/auth_token.js
+++ b/lib/auth_token.js
@@ -61,11 +61,11 @@ module.exports = function (options) {
   if (options.start_time != null) {
     tokenParts.push(`st=${options.start_time}`);
   }
-  if (Array.isArray(options.acl) === true) {
-    options.acl = options.acl.join("!");
-  }
   tokenParts.push(`exp=${options.expiration}`);
   if (options.acl != null) {
+    if (Array.isArray(options.acl) === true) {
+      options.acl = options.acl.join("!");
+    }
     tokenParts.push(`acl=${escapeToLower(options.acl)}`);
   }
   let toSign = [...tokenParts];

--- a/test/unit/authToken/authTokenUtils_spec.js
+++ b/test/unit/authToken/authTokenUtils_spec.js
@@ -66,4 +66,15 @@ describe("AuthToken tests using utils.generate_auth_token", function () {
       });
     }).not.to.throwError();
   });
+
+  it("should support multiple ACLs", function () {
+    let token = utils.generate_auth_token({
+      start_time: 222222222,
+      key: "00112233FF99",
+      duration: 300,
+      acl: ["/*/t_foobar", "t_foobar/*/"]
+    });
+
+    expect(token).to.eql("__cld_token__=st=222222222~exp=222222522~acl=%2f*%2ft_foobar!t_foobar%2f*%2f~hmac=45d51dd32dd26a3c2339155f454076c1d8fbd93c611965461569a0b4279bbdd5");
+  });
 });


### PR DESCRIPTION
### Brief Summary of Changes
Added support for multiple ACLs when generating auth tokens

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No