### PR TITLE
Add support for update method parameter clear_invalid

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -183,6 +183,9 @@ exports.update = function update(public_id, callback) {
   if (options.moderation_status != null) {
     params.moderation_status = options.moderation_status;
   }
+  if (options.clear_invalid != null) {
+    params.clear_invalid = options.clear_invalid;
+  }
   return call_api("post", uri, params, callback, options);
 };
 

--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -811,7 +811,8 @@ exports.update_metadata = function update_metadata(metadata, public_ids, callbac
       metadata: utils.encode_context(metadata),
       public_ids: utils.build_array(public_ids),
       timestamp: utils.timestamp(),
-      type: options.type
+      type: options.type,
+      clear_invalid: options.clear_invalid
     };
     return [params];
   });

--- a/lib/api.js
+++ b/lib/api.js
@@ -131,6 +131,9 @@ exports.update = function update(public_id, callback, options = {}) {
   if (options.moderation_status != null) {
     params.moderation_status = options.moderation_status;
   }
+  if (options.clear_invalid != null) {
+    params.clear_invalid = options.clear_invalid;
+  }
   return call_api("post", uri, params, callback, options);
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -131,7 +131,7 @@ exports.update = function update(public_id, callback, options = {}) {
   if (options.moderation_status != null) {
     params.moderation_status = options.moderation_status;
   }
-  if (options.clear_invalid != null) {
+  if (options.clear_invalid !== null) {
     params.clear_invalid = options.clear_invalid;
   }
   return call_api("post", uri, params, callback, options);

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -708,7 +708,8 @@ exports.update_metadata = function update_metadata(metadata, public_ids, callbac
       metadata: utils.encode_context(metadata),
       public_ids: utils.build_array(public_ids),
       timestamp: utils.timestamp(),
-      type: options.type
+      type: options.type,
+      clear_invalid: options.clear_invalid
     };
     return [params];
   });

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -891,16 +891,18 @@ describe("api", function () {
           }
         });
       });
-      it("should support updating metadata with clear_invalid", function () {
+      it("should support updating metadata with clear_invalid", () => {
         this.timeout(TIMEOUT.LONG);
-        return uploadImage({
-        }).then(upload_result => cloudinary.v2.api.update(upload_result.public_id, {
-          clear_invalid: true
-        })).then(function () {
-          if (writeSpy.called) {
-            sinon.assert.calledWith(writeSpy, sinon.match(/clear_invalid=true/));
-          }
-        });
+        return uploadImage()
+          .then(upload_result => {
+            return cloudinary.v2.api.update(upload_result.public_id, {
+              clear_invalid: true
+            });
+          }).then(() => {
+            if (writeSpy.called) {
+              sinon.assert.calledWith(writeSpy, sinon.match(/clear_invalid=true/));
+            }
+          });
       });
     });
     describe("quality override", function() {

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -891,6 +891,17 @@ describe("api", function () {
           }
         });
       });
+      it("should support updating metadata with clear_invalid", function () {
+        this.timeout(TIMEOUT.LONG);
+        return uploadImage({
+        }).then(upload_result => cloudinary.v2.api.update(upload_result.public_id, {
+          clear_invalid: true
+        })).then(function () {
+          if (writeSpy.called) {
+            sinon.assert.calledWith(writeSpy, sinon.match(/clear_invalid=true/));
+          }
+        });
+      });
     });
     describe("quality override", function() {
       const mocked = helper.mockTest();

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -1145,6 +1145,17 @@ describe("uploader", function () {
         sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("public_ids[]", public_ids[1])));
       });
     });
+    it("should support updating metadata with clear_invalid", function () {
+      const metadata_fields = { metadata_color: "red" };
+      const public_ids = ["test_id_1"];
+      return helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
+        cloudinary.v2.uploader.update_metadata(metadata_fields, public_ids, { clear_invalid: true });
+        sinon.assert.calledWith(requestSpy, sinon.match({
+          method: sinon.match("POST")
+        }));
+        sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("clear_invalid", true)));
+      });
+    })
   });
   describe("access_control", function () {
     var acl, acl_string, options, requestSpy, writeSpy;


### PR DESCRIPTION
### Brief Summary of Changes
Add support for parameter clear_invalid for update and update_metadata methods

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [X] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

