### PR TITLE
Hiding sensitive data on error

### DIFF
--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 // eslint-disable-next-line import/order
 var config = require("../config");
 var https = /^http:/.test(config().upload_prefix) ? require('http') : require('https');
@@ -74,12 +76,19 @@ function execute_request(method, params, auth, api_url, callback) {
     request_options.headers['Content-Length'] = Buffer.byteLength(query_params);
   }
   handle_response = function handle_response(res) {
-    const {hide_sensitive = false} = config();
-    const sanitized_request_options = {...request_options};
+    var _config = config(),
+        _config$hide_sensitiv = _config.hide_sensitive,
+        hide_sensitive = _config$hide_sensitiv === undefined ? false : _config$hide_sensitiv;
 
-    if (hide_sensitive === true){
-      if ("auth" in sanitized_request_options) { delete sanitized_request_options.auth; }
-      if ("Authorization" in sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
+    var sanitized_request_options = _extends({}, request_options);
+
+    if (hide_sensitive === true) {
+      if ("auth" in sanitized_request_options) {
+        delete sanitized_request_options.auth;
+      }
+      if ("Authorization" in sanitized_request_options.headers) {
+        delete sanitized_request_options.headers.Authorization;
+      }
     }
 
     if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
@@ -149,7 +158,7 @@ function execute_request(method, params, auth, api_url, callback) {
           request_options: sanitized_request_options,
           query_params,
           hide_sensitive
-      }
+        }
       };
       deferred.reject(err_obj.error);
       if (typeof callback === "function") {

--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -80,14 +80,14 @@ function execute_request(method, params, auth, api_url, callback) {
         _config$hide_sensitiv = _config.hide_sensitive,
         hide_sensitive = _config$hide_sensitiv === undefined ? false : _config$hide_sensitiv;
 
-    var sanitized_request_options = _extends({}, request_options);
+    var sanitizedOptions = _extends({}, request_options);
 
     if (hide_sensitive === true) {
-      if ("auth" in sanitized_request_options) {
-        delete sanitized_request_options.auth;
+      if ("auth" in sanitizedOptions) {
+        delete sanitizedOptions.auth;
       }
-      if ("Authorization" in sanitized_request_options.headers) {
-        delete sanitized_request_options.headers.Authorization;
+      if ("Authorization" in sanitizedOptions.headers) {
+        delete sanitizedOptions.headers.Authorization;
       }
     }
 
@@ -123,9 +123,8 @@ function execute_request(method, params, auth, api_url, callback) {
 
         if (result.error) {
           deferred.reject(Object.assign({
-            request_options: sanitized_request_options,
-            query_params,
-            hide_sensitive
+            request_options: sanitizedOptions,
+            query_params
           }, result));
         } else {
           deferred.resolve(result);
@@ -140,9 +139,8 @@ function execute_request(method, params, auth, api_url, callback) {
           error: {
             message: e,
             http_code: res.statusCode,
-            request_options: sanitized_request_options,
-            query_params,
-            hide_sensitive
+            request_options: sanitizedOptions,
+            query_params
           }
         };
         deferred.reject(err_obj.error);
@@ -155,9 +153,8 @@ function execute_request(method, params, auth, api_url, callback) {
         error: {
           message: "Server returned unexpected status code - " + res.statusCode,
           http_code: res.statusCode,
-          request_options: sanitized_request_options,
-          query_params,
-          hide_sensitive
+          request_options: sanitizedOptions,
+          query_params
         }
       };
       deferred.reject(err_obj.error);

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -8,11 +8,7 @@ const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
 const ProxyAgent = utils.optionalRequire('proxy-agent');
 
-const {
-  extend,
-  includes,
-  isEmpty
-} = utils;
+const { extend, includes, isEmpty } = utils;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -72,20 +72,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   }
   handle_response = function (res) {
     const {hide_sensitive = false} = config();
+    const sanitized_request_options = {...request_options};
 
-    // const sanitized_request_options = hide_sensitive ? reduce(request_options, (result, value, targetKey) => {
-    //   if (targetKey === 'auth') {
-    //     return result;
-    //   }
-    //   if (targetKey === 'headers') {
-    //     if (value.Authorization) {
-    //       delete value.Authorization;
-    //     }
-    //   }
-    //   return result[targetKey] = value;
-    // }, {}) : request_options;
-
-    const sanitized_request_options = {...request_options, hide_sensitive: hide_sensitive};
     if (hide_sensitive === true){
       if (sanitized_request_options.auth) { delete sanitized_request_options.auth; }
       if (sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
@@ -124,7 +112,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         if (result.error) {
           deferred.reject(Object.assign({
             request_options: sanitized_request_options,
-            query_params
+            query_params,
+            hide_sensitive
           }, result));
         } else {
           deferred.resolve(result);
@@ -140,7 +129,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
             message: e,
             http_code: res.statusCode,
             request_options: sanitized_request_options,
-            query_params
+            query_params,
+            hide_sensitive
           }
         };
         deferred.reject(err_obj.error);
@@ -154,18 +144,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
           message: "Server returned unexpected status code - " + res.statusCode,
           http_code: res.statusCode,
           request_options: sanitized_request_options,
-          // request_options: hide_sensitive ? reduce(request_options, (result, value, targetKey) => {
-          //   if (targetKey === 'auth') {
-          //     return result;
-          //   }
-          //   if (targetKey === 'headers') {
-          //     if (value.Authorization) {
-          //       delete value.Authorization;
-          //     }
-          //   }
-          //   return result[targetKey] = value;
-          // }, {}) : request_options,
-          query_params
+          query_params,
+          hide_sensitive
         }
       };
       deferred.reject(err_obj.error);

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -70,8 +70,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
     const sanitized_request_options = {...request_options};
 
     if (hide_sensitive === true){
-      if (sanitized_request_options.auth) { delete sanitized_request_options.auth; }
-      if (sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
+      if ("auth" in sanitized_request_options) { delete sanitized_request_options.auth; }
+      if ("Authorization" in sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
     }
 
     if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -8,7 +8,12 @@ const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
 const ProxyAgent = utils.optionalRequire('proxy-agent');
 
-const { extend, includes, isEmpty } = utils;
+const {
+  extend,
+  includes,
+  isEmpty,
+  reduce
+} = utils;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
@@ -124,11 +129,22 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         }
       });
     } else {
+      const {hide_sensitive = false} = config;
       let err_obj = {
         error: {
           message: "Server returned unexpected status code - " + res.statusCode,
           http_code: res.statusCode,
-          request_options,
+          request_options: hide_sensitive ? reduce(request_options, (result, value, key2) => {
+            if (key2 === 'auth') {
+              return result;
+            }
+            return result[key2] = value;
+            // if (key === 'headers') {
+            //   if (value.Authorization) {
+            //
+            //   }
+            // }
+          }, {}) : request_options,
           query_params
         }
       };

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -67,11 +67,11 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   }
   handle_response = function (res) {
     const {hide_sensitive = false} = config();
-    const sanitized_request_options = {...request_options};
+    const sanitizedOptions = {...request_options};
 
     if (hide_sensitive === true){
-      if ("auth" in sanitized_request_options) { delete sanitized_request_options.auth; }
-      if ("Authorization" in sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
+      if ("auth" in sanitizedOptions) { delete sanitizedOptions.auth; }
+      if ("Authorization" in sanitizedOptions.headers) { delete sanitizedOptions.headers.Authorization; }
     }
 
     if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
@@ -106,9 +106,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
 
         if (result.error) {
           deferred.reject(Object.assign({
-            request_options: sanitized_request_options,
-            query_params,
-            hide_sensitive
+            request_options: sanitizedOptions,
+            query_params
           }, result));
         } else {
           deferred.resolve(result);
@@ -123,9 +122,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
           error: {
             message: e,
             http_code: res.statusCode,
-            request_options: sanitized_request_options,
-            query_params,
-            hide_sensitive
+            request_options: sanitizedOptions,
+            query_params
           }
         };
         deferred.reject(err_obj.error);
@@ -138,9 +136,8 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         error: {
           message: "Server returned unexpected status code - " + res.statusCode,
           http_code: res.statusCode,
-          request_options: sanitized_request_options,
-          query_params,
-          hide_sensitive
+          request_options: sanitizedOptions,
+          query_params
         }
       };
       deferred.reject(err_obj.error);

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -11,8 +11,7 @@ const ProxyAgent = utils.optionalRequire('proxy-agent');
 const {
   extend,
   includes,
-  isEmpty,
-  reduce
+  isEmpty
 } = utils;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -71,6 +71,26 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
     request_options.headers['Content-Length'] = Buffer.byteLength(query_params);
   }
   handle_response = function (res) {
+    const {hide_sensitive = false} = config();
+
+    // const sanitized_request_options = hide_sensitive ? reduce(request_options, (result, value, targetKey) => {
+    //   if (targetKey === 'auth') {
+    //     return result;
+    //   }
+    //   if (targetKey === 'headers') {
+    //     if (value.Authorization) {
+    //       delete value.Authorization;
+    //     }
+    //   }
+    //   return result[targetKey] = value;
+    // }, {}) : request_options;
+
+    const sanitized_request_options = {...request_options, hide_sensitive: hide_sensitive};
+    if (hide_sensitive === true){
+      if (sanitized_request_options.auth) { delete sanitized_request_options.auth; }
+      if (sanitized_request_options.headers) { delete sanitized_request_options.headers.Authorization; }
+    }
+
     if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
       let buffer = "";
       let error = false;
@@ -103,7 +123,7 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
 
         if (result.error) {
           deferred.reject(Object.assign({
-            request_options,
+            request_options: sanitized_request_options,
             query_params
           }, result));
         } else {
@@ -119,7 +139,7 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
           error: {
             message: e,
             http_code: res.statusCode,
-            request_options,
+            request_options: sanitized_request_options,
             query_params
           }
         };
@@ -129,22 +149,22 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         }
       });
     } else {
-      const {hide_sensitive = false} = config;
       let err_obj = {
         error: {
           message: "Server returned unexpected status code - " + res.statusCode,
           http_code: res.statusCode,
-          request_options: hide_sensitive ? reduce(request_options, (result, value, key2) => {
-            if (key2 === 'auth') {
-              return result;
-            }
-            return result[key2] = value;
-            // if (key === 'headers') {
-            //   if (value.Authorization) {
-            //
-            //   }
-            // }
-          }, {}) : request_options,
+          request_options: sanitized_request_options,
+          // request_options: hide_sensitive ? reduce(request_options, (result, value, targetKey) => {
+          //   if (targetKey === 'auth') {
+          //     return result;
+          //   }
+          //   if (targetKey === 'headers') {
+          //     if (value.Authorization) {
+          //       delete value.Authorization;
+          //     }
+          //   }
+          //   return result[targetKey] = value;
+          // }, {}) : request_options,
           query_params
         }
       };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -29,6 +29,7 @@ const isNumber = require("lodash/isNumber");
 const isObject = require("lodash/isObject");
 const isString = require("lodash/isString");
 const isUndefined = require("lodash/isUndefined");
+const reduce = require("lodash/reduce");
 
 const smart_escape = require("./encoding/smart_escape");
 const consumeOption = require('./parsing/consumeOption');
@@ -1601,6 +1602,7 @@ Object.assign(module.exports, {
   isRemoteUrl,
   isString,
   isUndefined,
+  reduce,
   keys: source => Object.keys(source),
   ensurePresenceOf
 });

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -29,7 +29,6 @@ const isNumber = require("lodash/isNumber");
 const isObject = require("lodash/isObject");
 const isString = require("lodash/isString");
 const isUndefined = require("lodash/isUndefined");
-const reduce = require("lodash/reduce");
 
 const smart_escape = require("./encoding/smart_escape");
 const consumeOption = require('./parsing/consumeOption');
@@ -1602,7 +1601,6 @@ Object.assign(module.exports, {
   isRemoteUrl,
   isString,
   isUndefined,
-  reduce,
   keys: source => Object.keys(source),
   ensurePresenceOf
 });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -20,6 +20,32 @@ describe("config", function () {
     cloudinary.config(true);
   });
 
+  it("should support `hide_sensitive` config param", function () {
+    const config = cloudinary.config({hide_sensitive: true});
+    expect(config.hide_sensitive).to.eql(true)
+  });
+
+  it("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
+    try {
+      cloudinary.config({hide_sensitive: true});
+      const result = await cloudinary.v2.api.resource("?");
+      expect(result).fail();
+    } catch (err) {
+      console.log(err.request_options);
+      expect(err.request_options).not.to.have.property("auth");
+    }
+  });
+
+  it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
+    try {
+      cloudinary.config({hide_sensitive: true});
+      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
+      expect(result).fail();
+    } catch (err) {
+      console.log(err.request_options);
+      expect(err.request_options.headers).not.to.have.property("Authorization");
+    }
+  });
 
   it("should allow nested values in CLOUDINARY_URL", function () {
     process.env.CLOUDINARY_URL = "cloudinary://key:secret@test123?foo[bar]=value";
@@ -96,34 +122,5 @@ describe("config", function () {
     const proxy = "https://myuser:mypass@example.com"
     const config = cloudinary.config({api_proxy: proxy});
     expect(config.api_proxy).to.eql(proxy)
-  });
-
-  it("should support `hide_sensitive` config param", function () {
-    const config = cloudinary.config({hide_sensitive: true});
-    expect(config.hide_sensitive).to.eql(true)
-  });
-
-  it.only("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
-    cloudinary.config({hide_sensitive: true});
-
-    try {
-      const result = await cloudinary.v2.api.resource("?");
-      expect(result).fail();
-    } catch (err) {
-      console.log(err.request_options);
-      expect(err.request_options).not.to.have.property("auth");
-    }
-  });
-
-  it.only("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
-    cloudinary.config({hide_sensitive: true});
-
-    try {
-      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
-      expect(result).fail();
-    } catch (err) {
-      console.log(err.request_options);
-      expect(err.request_options.headers).not.to.have.property("Authorization");
-    }
   });
 });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -103,7 +103,7 @@ describe("config", function () {
     expect(config.hide_sensitive).to.eql(true)
   });
 
-  it.only("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
+  it("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
     cloudinary.config({hide_sensitive: true});
 
     try {
@@ -114,7 +114,7 @@ describe("config", function () {
     }
   });
 
-  it.only("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
+  it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
     cloudinary.config({hide_sensitive: true});
 
     try {

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -20,6 +20,11 @@ describe("config", function () {
     cloudinary.config(true);
   });
 
+  it("should not have a `hide_sensitive` property by default", function () {
+    const config = cloudinary.config();
+    expect(config).not.to.have.property("hide_sensitive");
+  });
+
   it("should support `hide_sensitive` config param", function () {
     const config = cloudinary.config({hide_sensitive: true});
     expect(config.hide_sensitive).to.eql(true)
@@ -38,7 +43,7 @@ describe("config", function () {
   it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
     try {
       cloudinary.config({hide_sensitive: true});
-      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
+      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'irrelevant' });
       expect(result).fail();
     } catch (err) {
       expect(err.request_options.headers).not.to.have.property("Authorization");

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -110,7 +110,7 @@ describe("config", function () {
       const result = await cloudinary.v2.api.resource("?");
       expect(result).fail();
     } catch (err) {
-      console.log(request_options);
+      console.log(err.request_options);
       expect(err.request_options).not.to.have.property("auth");
     }
   });
@@ -122,7 +122,7 @@ describe("config", function () {
       const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
       expect(result).fail();
     } catch (err) {
-      console.log(request_options);
+      console.log(err.request_options);
       expect(err.request_options.headers).not.to.have.property("Authorization");
     }
   });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -97,4 +97,31 @@ describe("config", function () {
     const config = cloudinary.config({api_proxy: proxy});
     expect(config.api_proxy).to.eql(proxy)
   });
+
+  it("should support `hide_sensitive` config param", function () {
+    const config = cloudinary.config({hide_sensitive: true});
+    expect(config.hide_sensitive).to.eql(true)
+  });
+
+  it.only("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
+    cloudinary.config({hide_sensitive: true});
+
+    try {
+      const result = await cloudinary.v2.api.resource("?");
+      expect(result).fail();
+    } catch (err) {
+      expect(err.request_options).not.to.have.property("auth");
+    }
+  });
+
+  it.only("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
+    cloudinary.config({hide_sensitive: true});
+
+    try {
+      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
+      expect(result).fail();
+    } catch (err) {
+      expect(err.request_options.headers).not.to.have.property("Authorization");
+    }
+  });
 });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -103,24 +103,26 @@ describe("config", function () {
     expect(config.hide_sensitive).to.eql(true)
   });
 
-  it("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
+  it.only("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
     cloudinary.config({hide_sensitive: true});
 
     try {
       const result = await cloudinary.v2.api.resource("?");
       expect(result).fail();
     } catch (err) {
+      console.log(request_options);
       expect(err.request_options).not.to.have.property("auth");
     }
   });
 
-  it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
+  it.only("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
     cloudinary.config({hide_sensitive: true});
 
     try {
       const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
       expect(result).fail();
     } catch (err) {
+      console.log(request_options);
       expect(err.request_options.headers).not.to.have.property("Authorization");
     }
   });

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -31,7 +31,6 @@ describe("config", function () {
       const result = await cloudinary.v2.api.resource("?");
       expect(result).fail();
     } catch (err) {
-      console.log(err.request_options);
       expect(err.request_options).not.to.have.property("auth");
     }
   });
@@ -42,7 +41,6 @@ describe("config", function () {
       const result = await cloudinary.v2.api.resource("?", { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
       expect(result).fail();
     } catch (err) {
-      console.log(err.request_options);
       expect(err.request_options.headers).not.to.have.property("Authorization");
     }
   });


### PR DESCRIPTION
### Brief Summary of Changes
Allows users to add `hide_sensitive` to their `cloudinary.config()` in order to ensure API key & secret, and Authorization header info is removed from error responses

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No