### PR TITLE
fix: 'os.tmpDir is not a function' on recent Node versions

### DIFF
--- a/samples/photo_album/controllers/photos_controller.js
+++ b/samples/photo_album/controllers/photos_controller.js
@@ -33,7 +33,7 @@ function create_through_server(req, res) {
   // and then saved to the database.
 
   // file was not uploaded redirecting to upload
-  if (req.files.image.ws.bytesWritten === 0) {
+  if (req.files.image.size === 0) {
     res.redirect('/photos/add');
     return;
   }

--- a/samples/photo_album/package.json
+++ b/samples/photo_album/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "body-parser": "^1.5.2",
     "cloudinary": "^1.3.0",
-    "connect-multiparty": "^1.1.0",
     "cloudinary-jquery-file-upload": "^2.0.1",
+    "connect-multiparty": "^2.2.0",
     "dotenv": "^0.4.0",
     "ejs": "^3.1.6",
     "ejs-locals": "^1.0.2",


### PR DESCRIPTION
### Brief Summary of Changes
Error observed when uploading a photo via the `Add photo` button on the photo-album sample:
```
TypeError: os.tmpDir is not a function
    at new Form (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/multiparty/index.js:55:44)
    at multipart (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/connect-multiparty/index.js:56:16)
    at Layer.handle [as handle_request] (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/route.js:144:13)
    at Route.dispatch (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/route.js:114:3)
    at Layer.handle [as handle_request] (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/layer.js:95:5)
    at /Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/node_modules/express/lib/router/index.js:280:10)
    at /Users/kevinreilly/Development/cloudinary_npm/samples/photo_album/server.js:53:7
```

Using Node version ^16 and likely lower, there is an `os` module breaking change where `os.tmpDir()` is now `os.tmpdir()`. This appears to be resolved and/or handled by a more recent version of the connect-multiparty module and upgrading it reveals a small incompatibility where `req.files.image.ws.bytesWritten` is no longer available, so, a potential guess solution has been applied by using `req.files.image.size` instead. This may be incorrect relative to the original intent.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
Decision to replace `req.files.image.ws.bytesWritten` with `req.files.image.size` may not be correct as the former no longer appears to be available with an upgraded version of connect-multiparty, though I'm not certain this meets the original expectations of evaluating the `bytesWritten`.
