### PR TITLE
fix: isRemoteUrl not working on big files sometimes

### DIFF
--- a/lib-es5/utils/isRemoteUrl.js
+++ b/lib-es5/utils/isRemoteUrl.js
@@ -8,7 +8,7 @@ var isString = require('lodash/isString');
  * @returns {boolean} true if the given url is a remote location or data
  */
 function isRemoteUrl(url) {
-  return isString(url) && /^ftp:|^https?:|^gs:|^s3:|^data:([\w-.]+\/[\w-.]+(\+[\w-.]+)?)?(;[\w-.]+=[\w-.]+)*;base64,([a-zA-Z0-9\/+\n=]+)$/.test(url);
+  return isString(url) && /^ftp:|^https?:|^gs:|^s3:|^data:/.test(url);
 }
 
 module.exports = isRemoteUrl;

--- a/lib/utils/isRemoteUrl.js
+++ b/lib/utils/isRemoteUrl.js
@@ -6,7 +6,7 @@ const isString = require('lodash/isString');
  * @returns {boolean} true if the given url is a remote location or data
  */
 function isRemoteUrl(url) {
-  return isString(url) && /^ftp:|^https?:|^gs:|^s3:|^data:([\w-.]+\/[\w-.]+(\+[\w-.]+)?)?(;[\w-.]+=[\w-.]+)*;base64,([a-zA-Z0-9\/+\n=]+)$/.test(url);
+  return isString(url) && /^ftp:|^https?:|^gs:|^s3:|^data:/.test(url);
 }
 
 module.exports = isRemoteUrl;


### PR DESCRIPTION
### Brief Summary of Changes
The idea is to remove the later part of the isRemoteUrl regex since you only need to check only the first characters to know if it's a remote URL or not.

We're having issues with the isRemoteUrl on production in some cases. here is the callstack for the error we're having:
```
RangeError: Maximum call stack size exceeded
 at RegExp.test (<anonymous>)
 at isRemoteUrl (/app/node_modules/cloudinary/lib/utils/isRemoteUrl.js:9:140)
 at /app/node_modules/cloudinary/lib/uploader.js:54:12
 at call_api (/app/node_modules/cloudinary/lib/uploader.js:466:52)
 at Object.upload (/app/node_modules/cloudinary/lib/uploader.js:52:10)
 at Object.upload (/app/node_modules/cloudinary/lib/utils/index.js:1260:21)
```

we're assuming the issue is related to applying the regex to big files when the application is under load with less resources available than usual. We're not able to reproduce the issue locally or with tests using the same files that broke, one piece of evidence to support this is the failing files are uploaded correctly afterward.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
