### PR TITLE
feat: add option to configure tracked analytics

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -897,17 +897,19 @@ function url(public_id) {
   }
 
   var urlAnalytics = ensureOption(options, 'urlAnalytics', false);
-  var trackedAnalytics = ensureOption(options, 'trackedAnalytics', false);
 
-  if (urlAnalytics === true || trackedAnalytics) {
-    var sdkVersions = getSDKVersions();
+  if (urlAnalytics === true) {
+    var { sdkCode, sdkSemver, techVersion } = getSDKVersions();
+    var sdkVersions = {
+      sdkCode: ensureOption(options, 'sdkCode', sdkCode),
+      sdkSemver: ensureOption(options, 'sdkSemver', sdkSemver),
+      techVersion: ensureOption(options, 'techVersion', techVersion)
+    };
 
-    if (trackedAnalytics) {
-      sdkVersions = trackedAnalytics;
-      sdkVersions.urlAnalytics = true;
-    }
-    
-    var analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
+    var analyticsOptions = getAnalyticsOptions(
+      Object.assign({}, options, sdkVersions)
+    );
+
     var sdkAnalyticsSignature = getSDKAnalyticsSignature(analyticsOptions);
 
     // url might already have a '?' query param

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -917,7 +917,7 @@ function url(public_id) {
     if (resultUrl.indexOf('?') >= 0) {
       appender = '&';
     }
-    resultUrl = `${resultUrl}${appender}_s=${sdkAnalyticsSignature}`;
+    resultUrl = `${resultUrl}${appender}_a=${sdkAnalyticsSignature}`;
   }
 
   return resultUrl;

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -897,11 +897,17 @@ function url(public_id) {
   }
 
   var urlAnalytics = ensureOption(options, 'urlAnalytics', false);
+  var trackedAnalytics = ensureOption(options, 'trackedAnalytics', false);
 
-  if (urlAnalytics === true) {
+  if (urlAnalytics === true || trackedAnalytics) {
     var sdkVersions = getSDKVersions();
-    var analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
 
+    if (trackedAnalytics) {
+      sdkVersions = trackedAnalytics;
+      sdkVersions.urlAnalytics = true;
+    }
+    
+    var analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
     var sdkAnalyticsSignature = getSDKAnalyticsSignature(analyticsOptions);
 
     // url might already have a '?' query param

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -827,17 +827,19 @@ function url(public_id, options = {}) {
   }
 
   let urlAnalytics = ensureOption(options, 'urlAnalytics', false);
-  let trackedAnalytics = ensureOption(options, 'trackedAnalytics', false);
 
-  if (urlAnalytics === true || trackedAnalytics) {
-    let sdkVersions = getSDKVersions();
+  if (urlAnalytics === true) {
+    let { sdkCode, sdkSemver, techVersion } = getSDKVersions();
+    let sdkVersions = {
+      sdkCode: ensureOption(options, 'sdkCode', sdkCode),
+      sdkSemver: ensureOption(options, 'sdkSemver', sdkSemver),
+      techVersion: ensureOption(options, 'techVersion', techVersion)
+    };
 
-    if (trackedAnalytics) {
-      sdkVersions = trackedAnalytics;
-      sdkVersions.urlAnalytics = true;
-    }
+    let analyticsOptions = getAnalyticsOptions(
+      Object.assign({}, options, sdkVersions)
+    );
 
-    let analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
     let sdkAnalyticsSignature = getSDKAnalyticsSignature(analyticsOptions);
 
     // url might already have a '?' query param

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -847,7 +847,7 @@ function url(public_id, options = {}) {
     if (resultUrl.indexOf('?') >= 0) {
       appender = '&';
     }
-    resultUrl = `${resultUrl}${appender}_s=${sdkAnalyticsSignature}`;
+    resultUrl = `${resultUrl}${appender}_a=${sdkAnalyticsSignature}`;
   }
 
   return resultUrl;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -827,11 +827,17 @@ function url(public_id, options = {}) {
   }
 
   let urlAnalytics = ensureOption(options, 'urlAnalytics', false);
+  let trackedAnalytics = ensureOption(options, 'trackedAnalytics', false);
 
-  if (urlAnalytics === true) {
+  if (urlAnalytics === true || trackedAnalytics) {
     let sdkVersions = getSDKVersions();
-    let analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
 
+    if (trackedAnalytics) {
+      sdkVersions = trackedAnalytics;
+      sdkVersions.urlAnalytics = true;
+    }
+
+    let analyticsOptions = getAnalyticsOptions(Object.assign({}, options, sdkVersions));
     let sdkAnalyticsSignature = getSDKAnalyticsSignature(analyticsOptions);
 
     // url might already have a '?' query param

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -73,11 +73,11 @@ describe('Tests for sdk analytics through image tag', function () {
 
     let imgStr = cloudinary.image("hello", {
       format: "png",
-      trackedAnalytics: {
-        sdkCode: "X",
-        sdkSemver: "7.3.0",
-        techVersion: "3.4.7"
-      }
+      urlAnalytics: true,
+      sdkCode: "X",
+      sdkSemver: "7.3.0",
+      techVersion: "3.4.7"
+      
     });
 
     expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AXAEzGT0`);

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -49,7 +49,7 @@ describe('Tests for sdk analytics through image tag', function () {
       urlAnalytics: true
     });
 
-    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AMAlhAM0`);
+    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_a=AMAlhAM0`);
   });
 
   it('Reads from process.versions and package.json (Mocked) - Responsive', () => {
@@ -63,7 +63,7 @@ describe('Tests for sdk analytics through image tag', function () {
       urlAnalytics: true
     });
 
-    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AMAlhAMA`);
+    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_a=AMAlhAMA`);
   });
 
   it('Reads from tracked analytics configuration', () => {
@@ -80,6 +80,6 @@ describe('Tests for sdk analytics through image tag', function () {
       
     });
 
-    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AXAEzGT0`);
+    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_a=AXAEzGT0`);
   });
 });

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -65,4 +65,21 @@ describe('Tests for sdk analytics through image tag', function () {
 
     expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AMAlhAMA`);
   });
+
+  it('Reads from tracked analytics configuration', () => {
+    process.versions = {
+      node: '12.0.0'
+    };
+
+    let imgStr = cloudinary.image("hello", {
+      format: "png",
+      trackedAnalytics: {
+        sdkCode: "X",
+        sdkSemver: "7.3.0",
+        techVersion: "3.4.7"
+      }
+    });
+
+    expect(imgStr).to.contain(`src='http://res.cloudinary.com/${TEST_CLOUD_NAME}/image/upload/hello.png?_s=AXAEzGT0`);
+  });
 });


### PR DESCRIPTION
### Brief Summary of Changes

Add similar behavior to @cloudinary/url-gen for configuring tracked analytics. Work done on stream with @colbyfayock so he should also be able to answer questions about the code.

#### What Does This PR Address?
- [X] GitHub issue (Add reference - #590)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
- View the description in #590
- Added one test but copied the expected tracking code from what it actually gave us, so make sure this is the expected tracking code
- ~Code changes only done in `lib`, not `lib-es5`~ now added
- Putting this as draft as I am not convinced we are done, but would still love a review

![CleanShot 2023-02-21 at 21 49 23@2x](https://user-images.githubusercontent.com/478531/220457201-e7902629-0af7-408e-8a74-246ddab93422.png)

