### PR TITLE
feat: passing context and metadata when using rename

### DIFF
--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -269,7 +269,9 @@ exports.rename = function rename(from_public_id, to_public_id, callback) {
       to_public_id: to_public_id,
       overwrite: options.overwrite,
       invalidate: options.invalidate,
-      to_type: options.to_type
+      to_type: options.to_type,
+      context: options.context,
+      metadata: options.metadata
     }];
   });
 };

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -220,7 +220,9 @@ exports.rename = function rename(from_public_id, to_public_id, callback, options
         to_public_id: to_public_id,
         overwrite: options.overwrite,
         invalidate: options.invalidate,
-        to_type: options.to_type
+        to_type: options.to_type,
+        context: options.context,
+        metadata: options.metadata
       }
     ];
   });

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -191,6 +191,14 @@ describe("uploader", function () {
         expect(format).to.eql("png");
       });
     });
+    it('should include tags in rename response if requested explicitly', async () => {
+      const uploadResult = await cloudinary.v2.uploader.upload(IMAGE_FILE, { context: 'alt=Example|class=Example', tags: ['test-tag'] });
+
+      const renameResult = await cloudinary.v2.uploader.rename(uploadResult.public_id, `${uploadResult.public_id}-renamed`, {tags: true, context: true});
+
+      expect(renameResult).to.have.property('tags');
+      expect(renameResult).to.have.property('context');
+    });
     return context(":invalidate", function () {
       var spy, xhr;
       spy = void 0;


### PR DESCRIPTION
### Brief Summary of Changes
Support for passing new parameters for `rename`:
```javascript
cloudinary.uploader.rename(oldPublicId, newPublicId, { context:true, metadata:true })
    .then(console.log)
    .catch(console.error);
```

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No