### PR TITLE
chore: overriding vulnerable transitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
   "optionalDependencies": {
     "proxy-agent": "^5.0.0"
   },
+  "overrides": {
+    "vm2": "3.9.16"
+  },
   "engines": {
     "node": ">=0.6"
   }


### PR DESCRIPTION
### Brief Summary of Changes
Adding `overrides` section to the package.json to avoid installing vulnerable `vm2@3.9.11` that is project's transitive dependency from `proxy-agent`.

#### What Does This PR Address?
- [X] GitHub issue (Add reference - #565)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No