### PR TITLE
fix: bumped vm2 override to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "proxy-agent": "^5.0.0"
   },
   "overrides": {
-    "vm2": "3.9.16"
+    "vm2": "3.9.17"
   },
   "engines": {
     "node": ">=0.6"


### PR DESCRIPTION
### Brief Summary of Changes
Bumped `vm2` override to `3.9.17`.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests
- [X] Security vulnerabilities

#### Are Tests Included?
- [ ] Yes
- [X] No