### PR TITLE
fix: smd number field allows both numbers and string when uploading

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -416,6 +416,9 @@ function encode_context(metadataObj) {
         return `\"${escapeMetadataValue(innerVal)}\"`
       }).join(',');
       return `${key}=[${values}]`
+      // if number, convert to string
+    } else if (Number.isInteger(value)) {
+      return `${key}=${escapeMetadataValue(String(value))}`;
       // if unknown, return the value as string
     } else {
       return value.toString();

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -1274,6 +1274,32 @@ describe("uploader", function () {
           expect(result.metadata[METADATA_FIELD_UNIQUE_EXTERNAL_ID]).to.eql(METADATA_FIELD_VALUE);
         });
     });
+    it('should allow passing both string and a number for a number smd field', () => {
+      const smdNumberField = 'smd_number_field';
+      cloudinary.v2.api.add_metadata_field({
+        external_id: smdNumberField,
+        label: smdNumberField,
+        type: 'number'
+      }).then(() => {
+        return Promise.all([
+          uploadImage({
+            tags: UPLOAD_TAGS,
+            metadata: {
+              [smdNumberField]: 123
+            }
+          }),
+          uploadImage({
+            tags: UPLOAD_TAGS,
+            metadata: {
+              [smdNumberField]: '123'
+            }
+          })
+        ]);
+      }).then(([firstUpload, secondUpload]) => {
+        expect(firstUpload.metadata[smdNumberField]).to.eql(123);
+        expect(secondUpload.metadata[smdNumberField]).to.eql(123);
+      });
+    });
     it("should be updatable with uploader.update_metadata on an existing resource", function () {
       let publicId;
       return uploadImage({


### PR DESCRIPTION
### Brief Summary of Changes
When passing structured metadata config while uploading a file, it wasn't possible to set number structured metadata field to a numeric value. Only strings were parsed correctly. This PR allows both strings and numbers be passed to a number structured metadata field.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix 
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No