### PR TITLE
fix: only explicit require used

### DIFF
--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -10,7 +10,6 @@ var Q = require('q');
 var url = require('url');
 var utils = require("../utils");
 var ensureOption = require('../utils/ensureOption').defaults(config());
-var ProxyAgent = utils.optionalRequire('proxy-agent');
 
 var extend = utils.extend,
     includes = utils.includes,
@@ -64,10 +63,12 @@ function execute_request(method, params, auth, api_url, callback) {
   var proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!request_options.agent) {
-      if (ProxyAgent === null) {
+      try {
+        var ProxyAgent = require('proxy-agent');
+        request_options.agent = new ProxyAgent(proxy);
+      } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");
       }
-      request_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib-es5/api_client/execute_request.js
+++ b/lib-es5/api_client/execute_request.js
@@ -10,6 +10,7 @@ var Q = require('q');
 var url = require('url');
 var utils = require("../utils");
 var ensureOption = require('../utils/ensureOption').defaults(config());
+var ProxyAgent = utils.optionalRequireProxyAgent();
 
 var extend = utils.extend,
     includes = utils.includes,
@@ -63,12 +64,10 @@ function execute_request(method, params, auth, api_url, callback) {
   var proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!request_options.agent) {
-      try {
-        var ProxyAgent = require('proxy-agent');
-        request_options.agent = new ProxyAgent(proxy);
-      } catch (requireError) {
+      if (ProxyAgent === null) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");
       }
+      request_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -34,7 +34,6 @@ var Cache = require('./cache');
 var utils = require("./utils");
 var UploadStream = require('./upload_stream');
 var config = require("./config");
-var ProxyAgent = utils.optionalRequire('proxy-agent');
 var ensureOption = require('./utils/ensureOption').defaults(config());
 
 var build_upload_params = utils.build_upload_params,
@@ -681,10 +680,13 @@ function post(url, post_data, boundary, file, callback, options) {
   var proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!post_options.agent) {
-      if (ProxyAgent === null) {
+      try {
+        var ProxyAgent = require('proxy-agent');
+        console.log('123');
+        post_options.agent = new ProxyAgent(proxy);
+      } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");
       }
-      post_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -35,6 +35,7 @@ var utils = require("./utils");
 var UploadStream = require('./upload_stream');
 var config = require("./config");
 var ensureOption = require('./utils/ensureOption').defaults(config());
+var ProxyAgent = utils.optionalRequireProxyAgent();
 
 var build_upload_params = utils.build_upload_params,
     extend = utils.extend,
@@ -680,12 +681,10 @@ function post(url, post_data, boundary, file, callback, options) {
   var proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!post_options.agent) {
-      try {
-        var ProxyAgent = require('proxy-agent');
-        post_options.agent = new ProxyAgent(proxy);
-      } catch (requireError) {
+      if (ProxyAgent === null) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");
       }
+      post_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib-es5/uploader.js
+++ b/lib-es5/uploader.js
@@ -682,7 +682,6 @@ function post(url, post_data, boundary, file, callback, options) {
     if (!post_options.agent) {
       try {
         var ProxyAgent = require('proxy-agent');
-        console.log('123');
         post_options.agent = new ProxyAgent(proxy);
       } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.");

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1669,19 +1669,6 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
-function optionalRequire(moduleName) {
-  var module = void 0;
-  try {
-    module = require(moduleName);
-    return module;
-  } catch (e) {
-    if (e.code === "MODULE_NOT_FOUND") {
-      return null;
-    }
-    throw e;
-  }
-}
-
 /**
  * Empty function - do nothing
  *
@@ -1739,7 +1726,6 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
-exports.optionalRequire = optionalRequire;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -1669,6 +1669,19 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
+function optionalRequireProxyAgent() {
+  var module = void 0;
+  try {
+    module = require('proxy-agent');
+    return module;
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw e;
+  }
+}
+
 /**
  * Empty function - do nothing
  *
@@ -1726,6 +1739,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.optionalRequireProxyAgent = optionalRequireProxyAgent;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -6,7 +6,6 @@ const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
-const ProxyAgent = utils.optionalRequire('proxy-agent');
 
 const { extend, includes, isEmpty } = utils;
 
@@ -54,10 +53,12 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   let proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!request_options.agent) {
-      if (ProxyAgent === null) {
+      try {
+        const ProxyAgent = require('proxy-agent');
+        request_options.agent = new ProxyAgent(proxy);
+      } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
       }
-      request_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -6,6 +6,7 @@ const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
+const ProxyAgent = utils.optionalRequireProxyAgent();
 
 const { extend, includes, isEmpty } = utils;
 
@@ -53,12 +54,10 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   let proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!request_options.agent) {
-      try {
-        const ProxyAgent = require('proxy-agent');
-        request_options.agent = new ProxyAgent(proxy);
-      } catch (requireError) {
+      if (ProxyAgent === null) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
       }
+      request_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -15,6 +15,7 @@ const utils = require("./utils");
 const UploadStream = require('./upload_stream');
 const config = require("./config");
 const ensureOption = require('./utils/ensureOption').defaults(config());
+const ProxyAgent = utils.optionalRequireProxyAgent();
 
 const {
   build_upload_params,
@@ -578,12 +579,10 @@ function post(url, post_data, boundary, file, callback, options) {
   let proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!post_options.agent) {
-      try {
-        const ProxyAgent = require('proxy-agent');
-        post_options.agent = new ProxyAgent(proxy);
-      } catch (requireError) {
+      if (ProxyAgent === null) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
       }
+      post_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -580,7 +580,6 @@ function post(url, post_data, boundary, file, callback, options) {
     if (!post_options.agent) {
       try {
         const ProxyAgent = require('proxy-agent');
-        console.log('123')
         post_options.agent = new ProxyAgent(proxy);
       } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -14,7 +14,6 @@ const Cache = require('./cache');
 const utils = require("./utils");
 const UploadStream = require('./upload_stream');
 const config = require("./config");
-const ProxyAgent = utils.optionalRequire('proxy-agent');
 const ensureOption = require('./utils/ensureOption').defaults(config());
 
 const {
@@ -579,10 +578,13 @@ function post(url, post_data, boundary, file, callback, options) {
   let proxy = options.api_proxy || config().api_proxy;
   if (!isEmpty(proxy)) {
     if (!post_options.agent) {
-      if (ProxyAgent === null) {
+      try {
+        const ProxyAgent = require('proxy-agent');
+        console.log('123')
+        post_options.agent = new ProxyAgent(proxy);
+      } catch (requireError) {
         throw new Error("Proxy value is set, but `proxy-agent` is not installed, please install `proxy-agent` module.")
       }
-      post_options.agent = new ProxyAgent(proxy);
     } else {
       console.warn("Proxy is set, but request uses a custom agent, proxy is ignored.");
     }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1533,19 +1533,6 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
-function optionalRequire(moduleName) {
-  let module;
-  try {
-    module = require(moduleName)
-    return module;
-  } catch (e) {
-    if (e.code === "MODULE_NOT_FOUND") {
-      return null;
-    }
-    throw e;
-  }
-}
-
 /**
  * Empty function - do nothing
  *
@@ -1601,7 +1588,6 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
-exports.optionalRequire = optionalRequire;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1533,6 +1533,19 @@ function jsonArrayParam(data, modifier) {
   return JSON.stringify(data);
 }
 
+function optionalRequireProxyAgent() {
+  let module;
+  try {
+    module = require('proxy-agent');
+    return module;
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      return null;
+    }
+    throw e;
+  }
+}
+
 /**
  * Empty function - do nothing
  *
@@ -1588,6 +1601,7 @@ exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
 exports.base_api_url = base_api_url;
 exports.download_backedup_asset = download_backedup_asset;
+exports.optionalRequireProxyAgent = optionalRequireProxyAgent;
 
 // was exported before, so kept for backwards compatibility
 exports.DEFAULT_POSTER_OPTIONS = DEFAULT_POSTER_OPTIONS;


### PR DESCRIPTION
### Brief Summary of Changes
- Removed `optionalRequire`, it was used only for `http-agent` anyway. Replaced that with explicit require but in a context where I can check whether require'ing it has to be enforced (which is only if someone uses the sdk with the `api_proxy` option.

#### What Does This PR Address?
- [X] GitHub issue (Add reference - #600)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No