### PR TITLE
fix: removing ts installed with dtslint to prevent fails on older node.js

### DIFF
--- a/tools/scripts/ditslint.sh
+++ b/tools/scripts/ditslint.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
+
+# IMPORTANT NOTE
+# The following line removes TS installed by dtslint because it caused a failure on Node.js < 12.
+# dtslint in its current version installs typescript@next which is failing on older Node.js.
+# Using --localTs does not fix the issue because interpreter first gets the code of dtslint and its dependencies.
+rm -rf node_modules/dtslint/node_modules/typescript
+
 dtslint --expectOnly --localTs node_modules/typescript/lib types


### PR DESCRIPTION
### Brief Summary of Changes
Removing `typescript` installed as a dependency of `dtslint`.
Why?
`dtslint` always installs `typescript@next` which probably caused our pipeline to start failing ~2 weeks ago.
Using `--localTs` did not help the issue.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests
- [X] Pipeline fix 

#### Are Tests Included?
- [ ] Yes
- [X] No