### PR TITLE
feat: basic asset relations api

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -16,7 +16,7 @@ function deleteResourcesParams(options) {
 }
 
 function getResourceParams(options) {
-  return pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "media_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis");
+  return pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "media_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis", 'related', 'related_next_cursor');
 }
 
 exports.ping = function ping(callback) {
@@ -262,28 +262,28 @@ exports.add_related_assets = function (publicId, assetsToRelate, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
   var params = createRelationParams(assetsToRelate);
-  return call_api('post', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+  return call_api('post', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
 };
 
 exports.add_related_assets_by_asset_id = function (assetId, assetsToRelate, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
   var params = createRelationParams(assetsToRelate);
-  return call_api('post', ['resources', assetId], params, callback, options);
+  return call_api('post', ['resources', 'related_assets', assetId], params, callback, options);
 };
 
 exports.delete_related_assets = function (publicId, assetsToUnrelate, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
   var params = deleteRelationParams(assetsToUnrelate);
-  return call_api('delete', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+  return call_api('delete', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
 };
 
 exports.delete_related_assets_by_asset_id = function (assetId, assetsToUnrelate, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
   var params = deleteRelationParams(assetsToUnrelate);
-  return call_api('delete', ['resources', assetId], params, callback, options);
+  return call_api('delete', ['resources', 'related_assets', assetId], params, callback, options);
 };
 
 exports.delete_derived_resources = function delete_derived_resources(derived_resource_ids, callback) {

--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -242,6 +242,50 @@ exports.delete_all_resources = function delete_all_resources(callback) {
   }), callback, options);
 };
 
+var createRelationParams = function createRelationParams() {
+  var publicIds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+
+  return {
+    assets_to_relate: Array.isArray(publicIds) ? publicIds : [publicIds]
+  };
+};
+
+var deleteRelationParams = function deleteRelationParams() {
+  var publicIds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+
+  return {
+    assets_to_unrelate: Array.isArray(publicIds) ? publicIds : [publicIds]
+  };
+};
+
+exports.add_related_assets = function (publicId, assetsToRelate, callback) {
+  var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  var params = createRelationParams(assetsToRelate);
+  return call_api('post', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+};
+
+exports.add_related_assets_by_asset_id = function (assetId, assetsToRelate, callback) {
+  var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  var params = createRelationParams(assetsToRelate);
+  return call_api('post', ['resources', assetId], params, callback, options);
+};
+
+exports.delete_related_assets = function (publicId, assetsToUnrelate, callback) {
+  var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  var params = deleteRelationParams(assetsToUnrelate);
+  return call_api('delete', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+};
+
+exports.delete_related_assets_by_asset_id = function (assetId, assetsToUnrelate, callback) {
+  var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+  var params = deleteRelationParams(assetsToUnrelate);
+  return call_api('delete', ['resources', assetId], params, callback, options);
+};
+
 exports.delete_derived_resources = function delete_derived_resources(derived_resource_ids, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
@@ -748,7 +792,10 @@ exports.order_metadata_field_datasource = function order_metadata_field_datasour
   var options = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
 
   options.content_type = "json";
-  var params = { order_by: sort_by, direction: direction };
+  var params = {
+    order_by: sort_by,
+    direction: direction
+  };
   return call_api("post", ["metadata_fields", field_external_id, "datasource", "order"], params, callback, options);
 };
 
@@ -766,7 +813,10 @@ exports.reorder_metadata_fields = function reorder_metadata_fields(order_by, dir
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
   options.content_type = "json";
-  var params = { order_by, direction };
+  var params = {
+    order_by,
+    direction
+  };
   return call_api("put", ["metadata_fields", "order"], params, callback, options);
 };
 

--- a/lib-es5/v2/api.js
+++ b/lib-es5/v2/api.js
@@ -70,5 +70,9 @@ v1_adapters(exports, api, {
   list_metadata_rules: 1,
   add_metadata_rule: 1,
   delete_metadata_rule: 1,
-  update_metadata_rule: 2
+  update_metadata_rule: 2,
+  add_related_assets: 2,
+  add_related_assets_by_asset_id: 2,
+  delete_related_assets: 2,
+  delete_related_assets_by_asset_id: 2
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,10 @@
 const utils = require("./utils");
 const call_api = require("./api_client/call_api");
 
-const { extend, pickOnlyExistingValues } = utils;
+const {
+  extend,
+  pickOnlyExistingValues
+} = utils;
 
 const TRANSFORMATIONS_URI = "transformations";
 
@@ -175,6 +178,38 @@ exports.delete_all_resources = function delete_all_resources(callback, options =
   }), callback, options);
 };
 
+const createRelationParams = (publicIds = []) => {
+  return {
+    assets_to_relate: Array.isArray(publicIds) ? publicIds : [publicIds]
+  };
+};
+
+const deleteRelationParams = (publicIds = []) => {
+  return {
+    assets_to_unrelate: Array.isArray(publicIds) ? publicIds : [publicIds]
+  };
+};
+
+exports.add_related_assets = (publicId, assetsToRelate, callback, options = {}) => {
+  const params = createRelationParams(assetsToRelate);
+  return call_api('post', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+};
+
+exports.add_related_assets_by_asset_id = (assetId, assetsToRelate, callback, options = {}) => {
+  const params = createRelationParams(assetsToRelate);
+  return call_api('post', ['resources', assetId], params, callback, options);
+};
+
+exports.delete_related_assets = (publicId, assetsToUnrelate, callback, options = {}) => {
+  const params = deleteRelationParams(assetsToUnrelate);
+  return call_api('delete', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+};
+
+exports.delete_related_assets_by_asset_id = (assetId, assetsToUnrelate, callback, options = {}) => {
+  const params = deleteRelationParams(assetsToUnrelate);
+  return call_api('delete', ['resources', assetId], params, callback, options);
+};
+
 exports.delete_derived_resources = function delete_derived_resources(derived_resource_ids, callback, options = {}) {
   let uri;
   uri = ["derived_resources"];
@@ -235,7 +270,7 @@ exports.update_transformation = function update_transformation(transformationNam
 };
 
 exports.create_transformation = function create_transformation(name, definition, callback, options = {}) {
-  const params = { name };
+  const params = {name};
   params.transformation = utils.build_eager(definition);
   return call_api("post", TRANSFORMATIONS_URI, params, callback, options);
 };
@@ -560,7 +595,7 @@ exports.update_metadata_field_datasource = function update_metadata_field_dataso
  */
 exports.delete_datasource_entries = function delete_datasource_entries(field_external_id, entries_external_id, callback, options = {}) {
   options.content_type = "json";
-  const params = { external_ids: entries_external_id };
+  const params = {external_ids: entries_external_id};
   return call_api("delete", ["metadata_fields", field_external_id, "datasource"], params, callback, options);
 };
 
@@ -581,7 +616,7 @@ exports.delete_datasource_entries = function delete_datasource_entries(field_ext
  */
 exports.restore_metadata_field_datasource = function restore_metadata_field_datasource(field_external_id, entries_external_id, callback, options = {}) {
   options.content_type = "json";
-  const params = { external_ids: entries_external_id };
+  const params = {external_ids: entries_external_id};
   return call_api("post", ["metadata_fields", field_external_id, "datasource_restore"], params, callback, options);
 };
 
@@ -597,7 +632,10 @@ exports.restore_metadata_field_datasource = function restore_metadata_field_data
  */
 exports.order_metadata_field_datasource = function order_metadata_field_datasource(field_external_id, sort_by, direction, callback, options = {}) {
   options.content_type = "json";
-  const params = { order_by: sort_by, direction: direction};
+  const params = {
+    order_by: sort_by,
+    direction: direction
+  };
   return call_api("post", ["metadata_fields", field_external_id, "datasource", "order"], params, callback, options);
 };
 
@@ -613,7 +651,10 @@ exports.order_metadata_field_datasource = function order_metadata_field_datasour
  */
 exports.reorder_metadata_fields = function reorder_metadata_fields(order_by, direction, callback, options = {}) {
   options.content_type = "json";
-  const params = { order_by, direction };
+  const params = {
+    order_by,
+    direction
+  };
   return call_api("put", ["metadata_fields", "order"], params, callback, options);
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,7 +13,7 @@ function deleteResourcesParams(options, params = {}) {
 }
 
 function getResourceParams(options) {
-  return pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "media_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis");
+  return pickOnlyExistingValues(options, "exif", "cinemagraph_analysis", "colors", "derived_next_cursor", "faces", "image_metadata", "media_metadata", "pages", "phash", "coordinates", "max_results", "versions", "accessibility_analysis", 'related', 'related_next_cursor');
 }
 
 exports.ping = function ping(callback, options = {}) {
@@ -192,22 +192,22 @@ const deleteRelationParams = (publicIds = []) => {
 
 exports.add_related_assets = (publicId, assetsToRelate, callback, options = {}) => {
   const params = createRelationParams(assetsToRelate);
-  return call_api('post', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+  return call_api('post', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
 };
 
 exports.add_related_assets_by_asset_id = (assetId, assetsToRelate, callback, options = {}) => {
   const params = createRelationParams(assetsToRelate);
-  return call_api('post', ['resources', assetId], params, callback, options);
+  return call_api('post', ['resources', 'related_assets', assetId], params, callback, options);
 };
 
 exports.delete_related_assets = (publicId, assetsToUnrelate, callback, options = {}) => {
   const params = deleteRelationParams(assetsToUnrelate);
-  return call_api('delete', ['resources', options.resource_type, options.type, publicId], params, callback, options);
+  return call_api('delete', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
 };
 
 exports.delete_related_assets_by_asset_id = (assetId, assetsToUnrelate, callback, options = {}) => {
   const params = deleteRelationParams(assetsToUnrelate);
-  return call_api('delete', ['resources', assetId], params, callback, options);
+  return call_api('delete', ['resources', 'related_assets', assetId], params, callback, options);
 };
 
 exports.delete_derived_resources = function delete_derived_resources(derived_resource_ids, callback, options = {}) {

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -68,5 +68,9 @@ v1_adapters(exports, api, {
   list_metadata_rules: 1,
   add_metadata_rule: 1,
   delete_metadata_rule: 1,
-  update_metadata_rule: 2
+  update_metadata_rule: 2,
+  add_related_assets: 2,
+  add_related_assets_by_asset_id: 2,
+  delete_related_assets: 2,
+  delete_related_assets_by_asset_id: 2
 });

--- a/test/integration/api/admin/related_assets_spec.js
+++ b/test/integration/api/admin/related_assets_spec.js
@@ -23,7 +23,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
         });
@@ -38,7 +38,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/${testPublicId}`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/${testPublicId}`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
         });
@@ -52,7 +52,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
         });
@@ -64,7 +64,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
         });
@@ -83,7 +83,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
         });
@@ -98,7 +98,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
         });
@@ -112,7 +112,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
         });
@@ -124,7 +124,7 @@ describe('Asset relations API', () => {
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
-          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
           deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
         });

--- a/test/integration/api/admin/related_assets_spec.js
+++ b/test/integration/api/admin/related_assets_spec.js
@@ -1,0 +1,134 @@
+const helper = require('../../../spechelper');
+const cloudinary = require('../../../../cloudinary');
+const {
+  strictEqual,
+  deepStrictEqual
+} = require('assert');
+const {TEST_CLOUD_NAME} = require('../../../testUtils/testConstants');
+
+describe('Asset relations API', () => {
+  const testPublicId = 'test-public-id';
+  const testAssetId = 'test-asset-id';
+  const singleRelatedPublicId = 'related-public-id';
+  const multipleRelatedPublicId = ['related-public-id-1', 'related-public-id-2'];
+
+  describe('when creating new relation', () => {
+    describe('using public id', () => {
+      it('should allow passing a single public id to create a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.add_related_assets(testPublicId, singleRelatedPublicId, {
+            resource_type: 'image',
+            type: 'upload'
+          });
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'POST');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
+        });
+      });
+
+      it('should allow passing multiple public ids to create a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.add_related_assets(testPublicId, multipleRelatedPublicId, {
+            resource_type: 'image',
+            type: 'upload'
+          });
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'POST');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/${testPublicId}`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
+        });
+      });
+    });
+
+    describe('using asset id', () => {
+      it('should allow passing a single public id to create a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, singleRelatedPublicId);
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'POST');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
+        });
+      });
+
+      it('should allow passing multiple public ids to create a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId);
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'POST');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
+        });
+      });
+    });
+  });
+
+  describe('when deleting existing relation', () => {
+    describe('using public id', () => {
+      it('should allow passing a single public id to delete a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.delete_related_assets(testPublicId, singleRelatedPublicId, {
+            resource_type: 'image',
+            type: 'upload'
+          });
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'DELETE');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
+        });
+      });
+
+      it('should allow passing multiple public ids to delete a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.delete_related_assets(testPublicId, multipleRelatedPublicId, {
+            resource_type: 'image',
+            type: 'upload'
+          });
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'DELETE');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/image/upload/test-public-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
+        });
+      });
+    });
+
+    describe('and using asset id', () => {
+      it('should allow passing a single public id to delete a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, singleRelatedPublicId);
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'DELETE');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
+        });
+      });
+
+      it('should allow passing multiple public ids to delete a relation', () => {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId);
+
+          const [calledWithUrl] = requestSpy.firstCall.args;
+          strictEqual(calledWithUrl.method, 'DELETE');
+          strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/test-asset-id`);
+          const callApiArguments = writeSpy.firstCall.args;
+          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
+        });
+      });
+    });
+  });
+});

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -1131,6 +1131,18 @@ cloudinary.v2.api.delete_folder('foo',{
     agent: new Http.Agent()
 });
 
+// $ExpectType Promise<NewAssetRelationResponse>
+cloudinary.v2.api.add_related_assets('public-id', 'public-id-to-relate');
+
+// $ExpectType Promise<NewAssetRelationResponse>
+cloudinary.v2.api.add_related_assets_by_asset_id('asset-id', 'public-id-to-relate');
+
+// $ExpectType Promise<DeleteAssetRelation>
+cloudinary.v2.api.delete_related_assets('public-id', 'public-id-to-unrelate');
+
+// $ExpectType Promise<DeleteAssetRelation>
+cloudinary.v2.api.delete_related_assets_by_asset_id('asset-id', 'public-id-to-unrelate');
+
 // $ExpectType Promise<any>
 cloudinary.v2.uploader.create_slideshow({
     manifest_json: {

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -9,10 +9,10 @@ cloudinary.v2.config();
 cloudinary.v2.config(true);
 
 // $ExpectType ConfigOptions
-cloudinary.v2.config({ cloud_name: "demo" });
+cloudinary.v2.config({cloud_name: "demo"});
 
 // $ExpectError
-cloudinary.v2.config({ cloud_name: 0 });
+cloudinary.v2.config({cloud_name: 0});
 
 // $ExpectType boolean | undefined
 cloudinary.v2.config("private_cdn");
@@ -237,19 +237,27 @@ cloudinary.v2.api.delete_derived_by_transformation(['image1', 'image2'], 'f_auto
 // $ExpectType Promise<any>
 cloudinary.v2.api.delete_derived_by_transformation(['image1', 'image2'], 'f_auto',
     {content_type: 'json'},
-    function(err,res){console.log(err);});
+    function (err, res) {
+        console.log(err);
+    });
 
 // $ExpectType Promise<any>
 cloudinary.v2.api.delete_derived_by_transformation(['image1', 'image2'], 'f_auto',
-    function(err,res){console.log(err);});
+    function (err, res) {
+        console.log(err);
+    });
 
 // $ExpectType Promise<any>
 cloudinary.v2.api.delete_derived_resources(['image1', 'image2'],
-    function (err,res){console.log(err);});
+    function (err, res) {
+        console.log(err);
+    });
 
 // $ExpectType Promise<any>
 cloudinary.v2.api.delete_derived_resources(['image1', 'image2'], {keep_original: true},
-    function (err,res){console.log(err);});
+    function (err, res) {
+        console.log(err);
+    });
 
 // $ExpectType Promise<any>
 cloudinary.v2.api.delete_resources_by_prefix('sunday',
@@ -331,7 +339,7 @@ cloudinary.v2.api.list_streaming_profiles(
     });
 
 // $ExpectType Promise<any>
-cloudinary.v2.api.list_streaming_profiles( {content_type: 'json'},
+cloudinary.v2.api.list_streaming_profiles({content_type: 'json'},
     function (err, res) {
         console.log(err);
     });
@@ -452,17 +460,17 @@ cloudinary.v2.api.resources_by_context("mycontextkey",
 
 // $ExpectType Promise<ResourceApiResponse>
 cloudinary.v2.api.resources_by_asset_ids(["asset_1", "asset_2"], {
-        context: true,
-        tags: true
-    }, function (error, result) {
-        console.log(result, error);
-    });
+    context: true,
+    tags: true
+}, function (error, result) {
+    console.log(result, error);
+});
 
 // $ExpectType Promise<ResourceApiResponse>
 cloudinary.v2.api.resources_by_asset_ids(["asset_1", "asset_2"], {
-        context: true,
-        tags: true
-    });
+    context: true,
+    tags: true
+});
 
 // $ExpectType Promise<ResourceApiResponse>
 cloudinary.v2.api.resources_by_asset_ids(["asset_1", "asset_2"],
@@ -625,43 +633,57 @@ cloudinary.v2.api.add_metadata_field({
     label: 'LABEL_INT_1',
     type: "integer",
     default_value: 10,
-}).then((result)=> {
+}).then((result) => {
     console.log(result);
 });
 
-cloudinary.v2.api.list_metadata_fields().then((result)=> {
+cloudinary.v2.api.list_metadata_fields().then((result) => {
     console.log(result.metadata_fields[0].datasource);
 });
 
 cloudinary.v2.api.delete_metadata_field('EXTERNAL_ID_GET_LIST').then((res) => {
-  console.log(res.message)
-}).catch((err)=> {console.log(err)})
-
-cloudinary.v2.api.update_metadata_field('EXTERNAL_ID_GET_LIST',{mandatory: true},
-    function (res) {
-    console.log(res);
+    console.log(res.message)
+}).catch((err) => {
+    console.log(err)
 })
+
+cloudinary.v2.api.update_metadata_field('EXTERNAL_ID_GET_LIST', {mandatory: true},
+    function (res) {
+        console.log(res);
+    })
 
 const datasource_changes = {
     values: [
-        { external_id: "color_1", value: "brown" },
-        { external_id: "color_2", value: "black" },
+        {external_id: "color_1", value: "brown"},
+        {external_id: "color_2", value: "black"},
     ],
 };
 
-cloudinary.v2.uploader.update_metadata({ metadata_color: "red", metadata_shape: "" }, ["test_id_1", "test_id_2"])
-    .then((res)=> {console.log(res)})
-    .catch((err)=> {console.log(err)});
+cloudinary.v2.uploader.update_metadata({metadata_color: "red", metadata_shape: ""}, ["test_id_1", "test_id_2"])
+    .then((res) => {
+        console.log(res)
+    })
+    .catch((err) => {
+        console.log(err)
+    });
 
-cloudinary.v2.uploader.update_metadata('countryFieldId=[\"id_us\",\"id_uk\",\"id_france"]', [ 'dog', 'lion' ],
-    function(error, result) { console.log(result, error) });
+cloudinary.v2.uploader.update_metadata('countryFieldId=[\"id_us\",\"id_uk\",\"id_france"]', ['dog', 'lion'],
+    function (error, result) {
+        console.log(result, error)
+    });
 
 cloudinary.v2.api.update_metadata_field_datasource('EXTERNAL_ID_GET_LIST1', datasource_changes)
-    .then((res)=> {console.log(res)})
-    .catch((err)=> {console.log(err)});
+    .then((res) => {
+        console.log(res)
+    })
+    .catch((err) => {
+        console.log(err)
+    });
 
 cloudinary.v2.api.delete_datasource_entries('EXTERNAL_ID_DELETE_DATASOURCE_ENTRIES', ['size_2'])
-    .then((res)=>{console.log(res)})
+    .then((res) => {
+        console.log(res)
+    })
 
 cloudinary.v2.api.add_metadata_rule({
     metadata_field_id: 'EXTERNAL_ID_GET_LIST',
@@ -852,7 +874,8 @@ cloudinary.v2.uploader.upload_large("my_large_video.mp4",
         resource_type: "video",
         chunk_size: 6000000
     },
-    function (error, result) {console.log(result, error);
+    function (error, result) {
+        console.log(result, error);
     });
 
 // $ExpectType Promise<UploadApiResponse>
@@ -872,8 +895,7 @@ cloudinary.v2.utils.download_zip_url(
 
 // $ExpectType { [key: string]: any; signature: string; api_key: string; }
 cloudinary.v2.utils.sign_request(
-    {
-    }
+    {}
 );
 
 // $ExpectType Promise<void>
@@ -951,7 +973,7 @@ cloudinary.v2.provisioning.account.sub_accounts(
 cloudinary.v2.provisioning.account.sub_account(
     'str',
     [],
-        (res) => {
+    (res) => {
 
     });
 
@@ -960,7 +982,7 @@ cloudinary.v2.provisioning.account.sub_account(
 cloudinary.v2.provisioning.account.create_sub_account(
     'str',
     'str',
-    {foo:'bar'},
+    {foo: 'bar'},
     false,
     'sds',
     {},
@@ -1120,14 +1142,14 @@ cloudinary.v2.utils.private_download_url('foo', 'foo', {
 
 
 // $ExpectType Promise<any>
-cloudinary.v2.api.create_folder('foo',{
+cloudinary.v2.api.create_folder('foo', {
     attachment: true,
     expires_at: 111
 });
 
 
 // $ExpectType Promise<any>
-cloudinary.v2.api.delete_folder('foo',{
+cloudinary.v2.api.delete_folder('foo', {
     agent: new Http.Agent()
 });
 
@@ -1135,13 +1157,25 @@ cloudinary.v2.api.delete_folder('foo',{
 cloudinary.v2.api.add_related_assets('public-id', 'public-id-to-relate');
 
 // $ExpectType Promise<NewAssetRelationResponse>
+cloudinary.v2.api.add_related_assets('public-id', ['public-id-to-relate-1', 'public-id-to-relate-2']);
+
+// $ExpectType Promise<NewAssetRelationResponse>
 cloudinary.v2.api.add_related_assets_by_asset_id('asset-id', 'public-id-to-relate');
+
+// $ExpectType Promise<NewAssetRelationResponse>
+cloudinary.v2.api.add_related_assets_by_asset_id('asset-id', ['public-id-to-relate-1', 'public-id-to-relate-2']);
 
 // $ExpectType Promise<DeleteAssetRelation>
 cloudinary.v2.api.delete_related_assets('public-id', 'public-id-to-unrelate');
 
 // $ExpectType Promise<DeleteAssetRelation>
+cloudinary.v2.api.delete_related_assets('public-id', ['public-id-to-unrelate-1', 'public-id-to-unrelate-2']);
+
+// $ExpectType Promise<DeleteAssetRelation>
 cloudinary.v2.api.delete_related_assets_by_asset_id('asset-id', 'public-id-to-unrelate');
+
+// $ExpectType Promise<DeleteAssetRelation>
+cloudinary.v2.api.delete_related_assets_by_asset_id('asset-id', ['public-id-to-unrelate-1', 'public-id-to-unrelate-2']);
 
 // $ExpectType Promise<any>
 cloudinary.v2.uploader.create_slideshow({
@@ -1151,5 +1185,5 @@ cloudinary.v2.uploader.create_slideshow({
     manifest_transformation: {
         width: 100
     },
-    height:100
+    height: 100
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -493,6 +493,7 @@ declare module 'cloudinary' {
         phash?: boolean;
         cinemagraph_analysis?: boolean;
         accessibility_analysis?: boolean;
+        related?: boolean;
 
         [futureKey: string]: any;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -642,6 +642,30 @@ declare module 'cloudinary' {
         http_code: number;
     }
 
+    export interface BaseAssetRelation {
+        asset: string;
+        status: 200;
+    }
+    export interface AssetRelationSuccess extends BaseAssetRelation {
+        message: 'success';
+        code: 'success_ids'
+    }
+
+    export interface AssetRelationAlreadyExists extends BaseAssetRelation {
+        message: 'resource already exists';
+        code: 'already_exists_ids';
+    }
+
+    export interface NewAssetRelationResponse {
+        failed: [any],
+        success: Array<AssetRelationSuccess | AssetRelationAlreadyExists>
+    }
+
+    export interface DeleteAssetRelation {
+        failed: [any],
+        success: Array<AssetRelationSuccess>
+    }
+
     export interface MetadataFieldApiOptions {
         external_id?: string;
         type?: string;
@@ -1091,6 +1115,14 @@ declare module 'cloudinary' {
             function create_folder(path: string, options?: AdminApiOptions, callback?: ResponseCallback): Promise<any>;
 
             function delete_folder(path: string, options?: AdminApiOptions, callback?: ResponseCallback): Promise<any>;
+
+            function add_related_assets(public_id: string, public_ids_to_relate: string | Array<string>, options?: AdminApiOptions, callback?: ResponseCallback): Promise<NewAssetRelationResponse>;
+
+            function add_related_assets_by_asset_id(asset_id: string, public_ids_to_relate: string | Array<string>, options?: AdminApiOptions, callback?: ResponseCallback): Promise<NewAssetRelationResponse>;
+
+            function delete_related_assets(public_id: string, public_ids_to_unrelate: string | Array<string>, options?: AdminApiOptions, callback?: ResponseCallback): Promise<DeleteAssetRelation>;
+
+            function delete_related_assets_by_asset_id(asset_id: string, public_ids_to_unrelate: string | Array<string>, options?: AdminApiOptions, callback?: ResponseCallback): Promise<DeleteAssetRelation>;
 
             /****************************** Structured Metadata API V2 Methods *************************************/
 


### PR DESCRIPTION
### Brief Summary of Changes
Exposing several new methods that support new Asset Relations API:
- `cloudinary.v2.add_related_assets`
- `cloudinary.v2.add_related_assets_by_asset_id`
- `cloudinary.v2.delete_related_assets`
- `cloudinary.v2.delete_related_assets_by_asset_id`
First argument is either a public ID or an asset ID (if using public ID, passing options and setting correct `resource_type` and `type` is recommended since defaults may incorrect in specific cases).
Second argument is either a single public ID or an array of multiple public IDs of assets that should be now related.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [X] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No