### PR TITLE
fix: adding clear_invalid only when not null

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -134,7 +134,7 @@ exports.update = function update(public_id, callback, options = {}) {
   if (options.moderation_status != null) {
     params.moderation_status = options.moderation_status;
   }
-  if (options.clear_invalid !== null) {
+  if (options.clear_invalid != null) {
     params.clear_invalid = options.clear_invalid;
   }
   return call_api("post", uri, params, callback, options);


### PR DESCRIPTION
### Brief Summary of Changes
Adding `clear_invalid` for options to the request only when it's not null.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No