### PR TITLE
fix: fetch overlay video creates correct transformation

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -225,7 +225,11 @@ function process_layer(layer) {
   var result = '';
   if (isPlainObject(layer)) {
     if (layer.resource_type === "fetch" || layer.url != null) {
-      result = `fetch:${base64EncodeURL(layer.url)}`;
+      if (layer.resource_type === 'video') {
+        result = `video:fetch:${base64EncodeURL(layer.url)}`;
+      } else {
+        result = `fetch:${base64EncodeURL(layer.url)}`;
+      }
     } else {
       var public_id = layer.public_id;
       var format = layer.format;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -209,7 +209,11 @@ function process_layer(layer) {
   let result = '';
   if (isPlainObject(layer)) {
     if (layer.resource_type === "fetch" || (layer.url != null)) {
-      result = `fetch:${base64EncodeURL(layer.url)}`;
+      if (layer.resource_type === 'video') {
+        result = `video:fetch:${base64EncodeURL(layer.url)}`;
+      } else {
+        result = `fetch:${base64EncodeURL(layer.url)}`;
+      }
     } else {
       let public_id = layer.public_id;
       let format = layer.format;

--- a/test/unit/tags/video_spec.js
+++ b/test/unit/tags/video_spec.js
@@ -7,6 +7,7 @@ cloudinary = require('../../../cloudinary');
 helper = require("../../spechelper");
 
 const createTestConfig = require('../../testUtils/createTestConfig');
+const assert = require("assert");
 
 describe("video tag helper", function () {
   var DEFAULT_UPLOAD_PATH, VIDEO_UPLOAD_PATH;
@@ -157,6 +158,16 @@ describe("video tag helper", function () {
     cloudinary.video('hello', options);
     expect(options.video_codec).to.eql('auto');
     expect(options.autoplay).to.be(true);
+  });
+  it('should generate working url for video with fetch overlay', () => {
+    const videoTag = cloudinary.video('video-public-id', {
+      transformation: [
+        { overlay: { url: 'https://res.cloudinary.com/demo/video/upload/electronic.mp4', resource_type: 'video' } },
+        { flags: 'layer_apply' }
+      ]
+    });
+
+    assert.strictEqual(videoTag, '<video poster=\'http://res.cloudinary.com/test123/video/upload/l_video:fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby92aWRlby91cGxvYWQvZWxlY3Ryb25pYy5tcDQ/fl_layer_apply/video-public-id.jpg\'><source src=\'http://res.cloudinary.com/test123/video/upload/l_video:fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby92aWRlby91cGxvYWQvZWxlY3Ryb25pYy5tcDQ/fl_layer_apply/video-public-id.webm\' type=\'video/webm\'><source src=\'http://res.cloudinary.com/test123/video/upload/l_video:fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby92aWRlby91cGxvYWQvZWxlY3Ryb25pYy5tcDQ/fl_layer_apply/video-public-id.mp4\' type=\'video/mp4\'><source src=\'http://res.cloudinary.com/test123/video/upload/l_video:fetch:aHR0cHM6Ly9yZXMuY2xvdWRpbmFyeS5jb20vZGVtby92aWRlby91cGxvYWQvZWxlY3Ryb25pYy5tcDQ/fl_layer_apply/video-public-id.ogv\' type=\'video/ogg\'></video>');
   });
 
   describe('sources', function() {


### PR DESCRIPTION
### Brief Summary of Changes
`.video` should generate correct url to a video with another video overlay.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No