### PR TITLE
fix: improved ResourceApiResponse interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -601,6 +601,16 @@ declare module 'cloudinary' {
 
     type UploadResponseCallback = (err?: UploadApiErrorResponse, callResult?: UploadApiResponse) => void;
 
+    export interface AdminApiPaginationResponse {
+        next_cursor?: string;
+    }
+
+    export interface AdminApiRateLimitingResponse {
+        rate_limit_allowed?: number;
+        rate_limit_reset_at?: string;
+        rate_limit_remaining?: number;
+    }
+
     export interface UploadApiResponse {
         public_id: string;
         version: number;
@@ -694,7 +704,7 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
-    export interface MetadataFieldsApiResponse {
+    export interface MetadataFieldsApiResponse extends AdminApiPaginationResponse, AdminApiRateLimitingResponse  {
         metadata_fields: MetadataFieldApiResponse[]
     }
 
@@ -776,7 +786,7 @@ declare module 'cloudinary' {
 
     export type MetadataRulesListResponse = Array<MetadataRuleResponse>;
 
-    export interface ResourceApiResponse {
+    export interface ResourceApiResponse extends AdminApiPaginationResponse, AdminApiRateLimitingResponse {
         resources: [
             {
                 public_id: string;
@@ -813,11 +823,7 @@ declare module 'cloudinary' {
 
                 [futureKey: string]: any;
             }
-        ],
-        next_cursor?: string;
-        rate_limit_allowed?: number;
-        rate_limit_reset_at?: string;
-        rate_limit_remaining?: number;
+        ]
     }
 
     export type SignApiOptions = Record<string, any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -813,7 +813,11 @@ declare module 'cloudinary' {
 
                 [futureKey: string]: any;
             }
-        ]
+        ],
+        next_cursor?: string;
+        rate_limit_allowed?: number;
+        rate_limit_reset_at?: string;
+        rate_limit_remaining?: number;
     }
 
     export type SignApiOptions = Record<string, any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -605,7 +605,7 @@ declare module 'cloudinary' {
         next_cursor?: string;
     }
 
-    export interface AdminApiRateLimitingResponse {
+    export interface AdminApiBaseResponse {
         rate_limit_allowed?: number;
         rate_limit_reset_at?: string;
         rate_limit_remaining?: number;
@@ -704,7 +704,7 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
-    export interface MetadataFieldsApiResponse extends AdminApiPaginationResponse, AdminApiRateLimitingResponse  {
+    export interface MetadataFieldsApiResponse extends AdminApiPaginationResponse, AdminApiBaseResponse  {
         metadata_fields: MetadataFieldApiResponse[]
     }
 
@@ -786,7 +786,7 @@ declare module 'cloudinary' {
 
     export type MetadataRulesListResponse = Array<MetadataRuleResponse>;
 
-    export interface ResourceApiResponse extends AdminApiPaginationResponse, AdminApiRateLimitingResponse {
+    export interface ResourceApiResponse extends AdminApiPaginationResponse, AdminApiBaseResponse {
         resources: [
             {
                 public_id: string;


### PR DESCRIPTION
### Brief Summary of Changes
`ResourceApiResponse` extended with these optional properties:
```typescript
next_cursor?: string;
rate_limit_allowed?: number;
rate_limit_reset_at?: string;
rate_limit_remaining?: number;
```

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
