### PR TITLE
fix: improved calculation of the signature in url

### DIFF
--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -49,7 +49,6 @@ var encodeDoubleArray = require('./encoding/encodeDoubleArray');
 
 var config = require("../config");
 var generate_token = require("../auth_token");
-var utf8_encode = require('./utf8_encode');
 var crc32 = require('./crc32');
 var ensurePresenceOf = require('./ensurePresenceOf');
 var ensureOption = require('./ensureOption').defaults(config());
@@ -425,7 +424,8 @@ function build_upload_params(options) {
     quality_override: options.quality_override,
     accessibility_analysis: utils.as_safe_bool(options.accessibility_analysis),
     use_asset_folder_as_public_id_prefix: utils.as_safe_bool(options.use_asset_folder_as_public_id_prefix),
-    visual_search: utils.as_safe_bool(options.visual_search)
+    visual_search: utils.as_safe_bool(options.visual_search),
+    on_success: options.on_success
   };
   return utils.updateable_resource_params(options, params);
 }
@@ -928,16 +928,20 @@ function url(public_id) {
     var to_sign = [transformation, source_to_sign].filter(function (part) {
       return part != null && part !== '';
     }).join('/');
-    try {
-      for (var i = 0; to_sign !== decodeURIComponent(to_sign) && i < 10; i++) {
-        to_sign = decodeURIComponent(to_sign);
-      }
-      // eslint-disable-next-line no-empty
-    } catch (error) {}
-    var hash = compute_hash(to_sign + api_secret, signature_algorithm, 'base64');
-    signature = hash.replace(/\//g, '_').replace(/\+/g, '-').substring(0, long_url_signature ? 32 : 8);
-    signature = `s--${signature}--`;
+
+    var signatureConfig = {};
+    if (long_url_signature) {
+      signatureConfig.algorithm = 'sha256';
+      signatureConfig.signatureLength = 32;
+    } else {
+      signatureConfig.algorithm = signature_algorithm;
+      signatureConfig.signatureLength = 8;
+    }
+
+    var truncated = compute_hash(to_sign + api_secret, signatureConfig.algorithm, 'base64').slice(0, signatureConfig.signatureLength).replace(/\//g, '_').replace(/\+/g, '-');
+    signature = `s--${truncated}--`;
   }
+
   var prefix = build_distribution_domain(public_id, options);
   var resultUrl = [prefix, resource_type, type, signature, transformation, version, public_id].filter(function (part) {
     return part != null && part !== '';
@@ -1156,9 +1160,8 @@ function compute_hash(input, signature_algorithm, encoding) {
   if (!SUPPORTED_SIGNATURE_ALGORITHMS.includes(signature_algorithm)) {
     throw new Error(`Signature algorithm ${signature_algorithm} is not supported. Supported algorithms: ${SUPPORTED_SIGNATURE_ALGORITHMS.join(', ')}`);
   }
-  var hash = crypto.createHash(signature_algorithm);
-  hash.update(utf8_encode(input), 'binary');
-  return hash.digest(encoding);
+  var hash = crypto.createHash(signature_algorithm).update(input).digest();
+  return Buffer.from(hash).toString(encoding);
 }
 
 function clear_blank(hash) {

--- a/lib-es5/utils/index.js
+++ b/lib-es5/utils/index.js
@@ -326,8 +326,14 @@ function process_layer(layer) {
   return components.join(':');
 }
 
+function replaceAllSubstrings(string, search) {
+  var replacement = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
+
+  return string.split(search).join(replacement);
+}
+
 function encodeCurlyBraces(input) {
-  return input.replaceAll('(', '%28').replaceAll(')', '%29');
+  return replaceAllSubstrings(replaceAllSubstrings(input, '(', '%28'), ')', '%29');
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -285,17 +285,17 @@ function process_layer(layer) {
     }
 
     if (!isEmpty(text)) {
-      let re = /\$\([a-zA-Z]\w*\)/g;
-      let start = 0;
-      let textSource = smart_escape(decodeURIComponent(text), /[,\/]/g);
-      text = "";
-      for (let res = re.exec(textSource); res; res = re.exec(textSource)) {
-        text += smart_escape(textSource.slice(start, res.index));
-        text += res[0];
-        start = res.index + res[0].length;
-      }
-      text += encodeURIComponent(textSource.slice(start));
-      components.push(text);
+      const variablesRegex = new RegExp(/(\$\([a-zA-Z]\w+\))/g);
+      const textDividedByVariables = text.split(variablesRegex).filter(x => x);
+      const encodedParts = textDividedByVariables.map(subText => {
+        const matches = variablesRegex[Symbol.match](subText);
+        const isVariable = matches ? matches.length > 0 : false;
+        if (isVariable) {
+          return subText;
+        }
+        return encodeCurlyBraces(encodeURIComponent(smart_escape(subText, new RegExp(/([,\/])/g))));
+      });
+      components.push(encodedParts.join(''));
     }
   } else if (type === 'fetch') {
     const encodedUrl = base64EncodeURL(fetchUrl);
@@ -306,6 +306,10 @@ function process_layer(layer) {
   }
 
   return components.join(':');
+}
+
+function encodeCurlyBraces(input) {
+  return input.replaceAll('(', '%28').replaceAll(')', '%29');
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -38,7 +38,6 @@ const encodeDoubleArray = require('./encoding/encodeDoubleArray');
 
 const config = require("../config");
 const generate_token = require("../auth_token");
-const utf8_encode = require('./utf8_encode');
 const crc32 = require('./crc32');
 const ensurePresenceOf = require('./ensurePresenceOf');
 const ensureOption = require('./ensureOption').defaults(config());
@@ -856,17 +855,23 @@ function url(public_id, options = {}) {
     let to_sign = [transformation, source_to_sign].filter(function (part) {
       return (part != null) && part !== '';
     }).join('/');
-    try {
-      for (let i = 0; to_sign !== decodeURIComponent(to_sign) && i < 10; i++) {
-        to_sign = decodeURIComponent(to_sign);
-      }
-      // eslint-disable-next-line no-empty
-    } catch (error) {
+
+    const signatureConfig = {};
+    if (long_url_signature) {
+      signatureConfig.algorithm = 'sha256';
+      signatureConfig.signatureLength = 32;
+    } else {
+      signatureConfig.algorithm = signature_algorithm;
+      signatureConfig.signatureLength = 8;
     }
-    let hash = compute_hash(to_sign + api_secret, signature_algorithm, 'base64');
-    signature = hash.replace(/\//g, '_').replace(/\+/g, '-').substring(0, long_url_signature ? 32 : 8);
-    signature = `s--${signature}--`;
+
+    const truncated = compute_hash(to_sign + api_secret, signatureConfig.algorithm, 'base64')
+      .slice(0, signatureConfig.signatureLength)
+      .replace(/\//g, '_')
+      .replace(/\+/g, '-');
+    signature = `s--${truncated}--`;
   }
+
   let prefix = build_distribution_domain(public_id, options);
   let resultUrl = [prefix, resource_type, type, signature, transformation, version, public_id].filter(function (part) {
     return (part != null) && part !== '';
@@ -1080,9 +1085,8 @@ function compute_hash(input, signature_algorithm, encoding) {
   if (!SUPPORTED_SIGNATURE_ALGORITHMS.includes(signature_algorithm)) {
     throw new Error(`Signature algorithm ${signature_algorithm} is not supported. Supported algorithms: ${SUPPORTED_SIGNATURE_ALGORITHMS.join(', ')}`);
   }
-  let hash = crypto.createHash(signature_algorithm);
-  hash.update(utf8_encode(input), 'binary');
-  return hash.digest(encoding);
+  const hash = crypto.createHash(signature_algorithm).update(input).digest();
+  return Buffer.from(hash).toString(encoding);
 }
 
 function clear_blank(hash) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -308,8 +308,12 @@ function process_layer(layer) {
   return components.join(':');
 }
 
+function replaceAllSubstrings(string, search, replacement = '') {
+  return string.split(search).join(replacement);
+}
+
 function encodeCurlyBraces(input) {
-  return input.replaceAll('(', '%28').replaceAll(')', '%29');
+  return replaceAllSubstrings(replaceAllSubstrings(input, '(', '%28'), ')', '%29');
 }
 
 /**

--- a/test/unit/url/overlay_underlay_spec.js
+++ b/test/unit/url/overlay_underlay_spec.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const cloudinary = require('../../../lib/cloudinary');
+
+describe('URL utils with transformation parameters', () => {
+  const CLOUD_NAME = 'test-cloud';
+
+  before(() => {
+    cloudinary.config({
+      cloud_name: CLOUD_NAME
+    });
+  });
+
+  it('should create a correct link with overlay string', () => {
+    const url = cloudinary.utils.url('test', {
+      overlay: {
+        font_family: "arial",
+        font_size: "30",
+        text: "abc,αβγ/אבג"
+      }
+    });
+
+    assert.strictEqual(url, `http://res.cloudinary.com/${CLOUD_NAME}/image/upload/l_text:arial_30:abc%252C%CE%B1%CE%B2%CE%B3%252F%D7%90%D7%91%D7%92/test`);
+  });
+
+  it('should create a correct link with underlay string', () => {
+    const url = cloudinary.utils.url('test', {
+      underlay: {
+        font_family: "arial",
+        font_size: "30",
+        text: "abc,αβγ/אבג"
+      }
+    });
+
+    assert.strictEqual(url, `http://res.cloudinary.com/${CLOUD_NAME}/image/upload/u_text:arial_30:abc%252C%CE%B1%CE%B2%CE%B3%252F%D7%90%D7%91%D7%92/test`);
+  });
+});

--- a/test/unit/url/sign_url_spec.js
+++ b/test/unit/url/sign_url_spec.js
@@ -1,0 +1,110 @@
+const cloudinary = require('../../../lib/cloudinary');
+const assert = require('assert');
+
+const TEST_CLOUD_NAME = 'test123';
+const TEST_API_KEY = '1234';
+const TEST_API_SECRET = 'b';
+
+
+describe("URL for authenticated asset", () => {
+  before(function () {
+    cloudinary.config({
+      cloud_name: TEST_CLOUD_NAME,
+      api_key: TEST_API_KEY,
+      api_secret: TEST_API_SECRET
+    });
+  });
+
+  let TEST_PUBLIC_ID = 'image.jpg';
+  it('should have signature for transformation and version', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      version: 1234,
+      transformation: {
+        crop: "crop",
+        width: 10,
+        height: 20
+      },
+      sign_url: true
+    });
+
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/upload/s--Ai4Znfl3--/c_crop,h_20,w_10/v1234/image.jpg');
+  });
+
+  it('should have signature for version', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      version: 1234,
+      sign_url: true
+    });
+
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/upload/s----SjmNDA--/v1234/image.jpg');
+  });
+
+  it('should have signature for transformation', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      transformation: {
+        crop: "crop",
+        width: 10,
+        height: 20
+      },
+      sign_url: true
+    });
+
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/upload/s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg');
+  });
+
+  it('should have signature for authenticated asset with transformation', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      type: 'authenticated',
+      transformation: {
+        crop: "crop",
+        width: 10,
+        height: 20
+      },
+      sign_url: true
+    });
+
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/authenticated/s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg');
+  });
+
+  it('should have signature for fetched asset', () => {
+    const signedUrl = cloudinary.utils.url('http://google.com/path/to/image.png', {
+      type: 'fetch',
+      version: 1234,
+      sign_url: true
+    });
+
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/fetch/s--hH_YcbiS--/v1234/http://google.com/path/to/image.png');
+  });
+
+  it('should have signature for authenticated asset with text overlay transformation including encoded text', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      type: 'authenticated',
+      sign_url: true,
+      secure: true,
+      transformation: {
+        color: 'red',
+        overlay: {
+          text: 'Cool%25F0%259F%2598%258D',
+          font_family: 'Times',
+          font_size: 70,
+          font_weight: 'bold'
+        }
+      }
+    });
+
+    assert.strictEqual(signedUrl, 'https://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
+  });
+
+  it('should have signature for raw transformation string', () => {
+    const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
+      type: 'authenticated',
+      sign_url: true,
+      secure: true,
+      transformation: {
+        raw_transformation: 'co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D'
+      }
+    });
+
+    assert.strictEqual(signedUrl, 'https://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
+  });
+})

--- a/test/unit/url/sign_url_spec.js
+++ b/test/unit/url/sign_url_spec.js
@@ -76,7 +76,7 @@ describe("URL for authenticated asset", () => {
     assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/fetch/s--hH_YcbiS--/v1234/http://google.com/path/to/image.png');
   });
 
-  it.only('should have signature for authenticated asset with text overlay transformation including encoded emoji', () => {
+  it('should have signature for authenticated asset with text overlay transformation including encoded emoji', () => {
     const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
       type: 'authenticated',
       sign_url: true,

--- a/test/unit/url/sign_url_spec.js
+++ b/test/unit/url/sign_url_spec.js
@@ -76,15 +76,14 @@ describe("URL for authenticated asset", () => {
     assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/fetch/s--hH_YcbiS--/v1234/http://google.com/path/to/image.png');
   });
 
-  it('should have signature for authenticated asset with text overlay transformation including encoded text', () => {
+  it.only('should have signature for authenticated asset with text overlay transformation including encoded emoji', () => {
     const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
       type: 'authenticated',
       sign_url: true,
-      secure: true,
       transformation: {
         color: 'red',
         overlay: {
-          text: 'Cool%25F0%259F%2598%258D',
+          text: 'Cool%F0%9F%98%8D',
           font_family: 'Times',
           font_size: 70,
           font_weight: 'bold'
@@ -92,19 +91,18 @@ describe("URL for authenticated asset", () => {
       }
     });
 
-    assert.strictEqual(signedUrl, 'https://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
   });
 
   it('should have signature for raw transformation string', () => {
     const signedUrl = cloudinary.utils.url(TEST_PUBLIC_ID, {
       type: 'authenticated',
       sign_url: true,
-      secure: true,
       transformation: {
         raw_transformation: 'co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D'
       }
     });
 
-    assert.strictEqual(signedUrl, 'https://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
+    assert.strictEqual(signedUrl, 'http://res.cloudinary.com/test123/image/authenticated/s--Uqk1a-5W--/co_red,l_text:Times_70_bold:Cool%25F0%259F%2598%258D/image.jpg');
   });
 })

--- a/test/unit/url/user_defined_variables_spec.js
+++ b/test/unit/url/user_defined_variables_spec.js
@@ -1,0 +1,99 @@
+const assert = require('assert');
+const cloudinary = require('../../../lib/cloudinary');
+
+describe('User Define Variables', function () {
+  const CLOUD_NAME = 'test';
+
+  before(() => {
+    cloudinary.config({
+      cloud_name: CLOUD_NAME
+    });
+  });
+
+  it('array should define a set of variables', function () {
+    var options, t;
+    options = {
+      if: 'face_count > 2',
+      variables: [['$z', 5], ['$foo', '$z * 2']],
+      crop: 'scale',
+      width: '$foo * 200'
+    };
+    t = cloudinary.utils.generate_transformation_string(options);
+    expect(t).to.eql('if_fc_gt_2,$z_5,$foo_$z_mul_2,c_scale,w_$foo_mul_200');
+  });
+
+  it('"$key" should define a variable', function () {
+    var options, t;
+    options = {
+      transformation: [
+        {
+          $foo: 10
+        },
+        {
+          if: 'face_count > 2'
+        },
+        {
+          crop: 'scale',
+          width: '$foo * 200 / face_count'
+        },
+        {
+          if: 'end'
+        }
+      ]
+    };
+    t = cloudinary.utils.generate_transformation_string(options);
+    expect(t).to.eql('$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end');
+  });
+
+  it('should support power operator', function () {
+    var options, t;
+    options = {
+      transformation: [
+        {
+          $small: 150,
+          $big: '$small ^ 1.5'
+        }
+      ]
+    };
+    t = cloudinary.utils.generate_transformation_string(options);
+    expect(t).to.eql('$big_$small_pow_1.5,$small_150');
+  });
+
+  it('should not change variable names even if they look like keywords', function () {
+    var options, t;
+    options = {
+      transformation: [
+        {
+          $width: 10
+        },
+        {
+          width: '$width + 10 + width'
+        }
+      ]
+    };
+    t = cloudinary.utils.generate_transformation_string(options);
+    expect(t).to.eql('$width_10/w_$width_add_10_add_w');
+  });
+
+  it('should support text values', function () {
+    const url = cloudinary.utils.url('sample', {
+      effect: '$efname:100',
+      $efname: '!blur!'
+    });
+
+    assert.strictEqual(url, `http://res.cloudinary.com/${CLOUD_NAME}/image/upload/$efname_!blur!,e_$efname:100/sample`);
+  });
+
+  it('should support string interpolation', function () {
+    const url = cloudinary.utils.url('sample', {
+      crop: 'scale',
+      overlay: {
+        text: '$(start)Hello $(name)$(ext), $(no ) $( no)$(end)',
+        font_family: 'Arial',
+        font_size: '18'
+      }
+    });
+
+    assert.strictEqual(url, `http://res.cloudinary.com/${CLOUD_NAME}/image/upload/c_scale,l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/sample`);
+  });
+});

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -1558,52 +1558,6 @@ describe("utils", function () {
       ).to.eql(false);
     });
   });
-  context("sign URLs", function () {
-    beforeEach(function () {
-      cloudinary.config({
-        cloud_name: 'test123',
-        api_key: "1234",
-        api_secret: "b"
-      });
-    });
-    it("should correctly sign URLs", function () {
-      test_cloudinary_url("image.jpg", {
-        version: 1234,
-        transformation: {
-          crop: "crop",
-          width: 10,
-          height: 20
-        },
-        sign_url: true
-      }, "http://res.cloudinary.com/test123/image/upload/s--Ai4Znfl3--/c_crop,h_20,w_10/v1234/image.jpg", {});
-      test_cloudinary_url("image.jpg", {
-        version: 1234,
-        sign_url: true
-      }, "http://res.cloudinary.com/test123/image/upload/s----SjmNDA--/v1234/image.jpg", {});
-      test_cloudinary_url("image.jpg", {
-        transformation: {
-          crop: "crop",
-          width: 10,
-          height: 20
-        },
-        sign_url: true
-      }, "http://res.cloudinary.com/test123/image/upload/s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg", {});
-      test_cloudinary_url("image.jpg", {
-        transformation: {
-          crop: "crop",
-          width: 10,
-          height: 20
-        },
-        type: 'authenticated',
-        sign_url: true
-      }, "http://res.cloudinary.com/test123/image/authenticated/s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg", {});
-      test_cloudinary_url("http://google.com/path/to/image.png", {
-        type: "fetch",
-        version: 1234,
-        sign_url: true
-      }, "http://res.cloudinary.com/test123/image/fetch/s--hH_YcbiS--/v1234/http://google.com/path/to/image.png", {});
-    });
-  });
   context("sign requests", function () {
     var configBck = void 0;
     before(function () {

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -718,15 +718,6 @@ describe("utils", function () {
           "text:hello",
           "text:hello"],
         [
-          "string",
-          {
-            "font_family": "arial",
-            "font_size": "30",
-            "text": "abc,αβγ/אבג"
-          },
-          "text:arial_30:abc%252C%CE%B1%CE%B2%CE%B3%252F%D7%90%D7%91%D7%92"
-        ],
-        [
           "public_id",
           {
             "public_id": "logo"
@@ -1064,87 +1055,6 @@ describe("utils", function () {
         }
         expect(cloudinary.utils.generate_transformation_string(options))
           .to.contain('$xpos_ctx:!x_pos!_to_f,$ypos_ctx:!y_pos!_to_f,c_crop,x_$xpos_mul_w,y_$ypos_mul_h')
-      });
-    });
-    describe('User Define Variables', function () {
-      it("array should define a set of variables", function () {
-        var options, t;
-        options = {
-          if: "face_count > 2",
-          variables: [["$z", 5], ["$foo", "$z * 2"]],
-          crop: "scale",
-          width: "$foo * 200"
-        };
-        t = cloudinary.utils.generate_transformation_string(options);
-        expect(t).to.eql("if_fc_gt_2,$z_5,$foo_$z_mul_2,c_scale,w_$foo_mul_200");
-      });
-      it("'$key' should define a variable", function () {
-        var options, t;
-        options = {
-          transformation: [
-            {
-              $foo: 10
-            },
-            {
-              if: "face_count > 2"
-            },
-            {
-              crop: "scale",
-              width: "$foo * 200 / face_count"
-            },
-            {
-              if: "end"
-            }
-          ]
-        };
-        t = cloudinary.utils.generate_transformation_string(options);
-        expect(t).to.eql("$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end");
-      });
-
-      it("should not change variable names even if they look like keywords", function () {
-        var options, t;
-        options = {
-          transformation: [
-            {
-              $width: 10
-            },
-            {
-              width: "$width + 10 + width"
-            }
-          ]
-        };
-        t = cloudinary.utils.generate_transformation_string(options);
-        expect(t).to.eql("$width_10/w_$width_add_10_add_w");
-      });
-
-      it("should support text values", function () {
-        test_cloudinary_url("sample", {
-          effect: "$efname:100",
-          $efname: "!blur!"
-        }, `http://res.cloudinary.com/${cloud_name}/image/upload/$efname_!blur!,e_$efname:100/sample`, {});
-      });
-      it("should support string interpolation", function () {
-        test_cloudinary_url("sample", {
-          crop: "scale",
-          overlay: {
-            text: "$(start)Hello $(name)$(ext), $(no ) $( no)$(end)",
-            font_family: "Arial",
-            font_size: "18"
-          }
-        }, `http://res.cloudinary.com/${cloud_name}/image/upload/c_scale,l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/sample`, {});
-      });
-      it("should support power operator", function () {
-        var options, t;
-        options = {
-          transformation: [
-            {
-              $small: 150,
-              $big: "$small ^ 1.5"
-            }
-          ]
-        };
-        t = cloudinary.utils.generate_transformation_string(options);
-        expect(t).to.eql("$big_$small_pow_1.5,$small_150");
       });
     });
     describe("text", function () {


### PR DESCRIPTION
### Brief Summary of Changes
- Improved and simplified the `compute_hash` function to reflect the same behaviour as in python's sdk
- Removed empty file
- Improved readability and simplified series of test cases for signed URLs
  - Previously unnecessary abstraction layer was used, instead of explicit `assert` from the standard library. Also, mocha's `describe` is used instead of the unnecessary custom one.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
This change may seem to be dangerous, but in order to ensure correctness, I'm going to create additional PR to python SDK containing two new specs that I added here: `test/unit/url/sign_url_spec.js:79` and `test/unit/url/sign_url_spec.js:98`.