### PR TITLE
Visual search file upload

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 const utils = require("./utils");
 const call_api = require("./api_client/call_api");
+const fs = require("fs");
 
 const {
   extend,
@@ -439,8 +440,22 @@ exports.search = function search(params, callback, options = {}) {
   return call_api("post", "resources/search", params, callback, options);
 };
 
+function handleImageFile(image_file) {
+  if (Buffer.isBuffer(image_file)) {
+    return image_file;
+  }
+  if (typeof image_file === 'string') {
+    return fs.createReadStream(image_file);
+  }
+  throw new Error('image_file has to be either a path to file or a buffer');
+}
+
 exports.visual_search = function visual_search(params, callback, options = {}) {
-  const allowedParams = pickOnlyExistingValues(params, 'image_url', 'image_asset_id', 'text');
+  const allowedParams = pickOnlyExistingValues(params, 'image_url', 'image_asset_id', 'text', 'image_file');
+  if ('image_file' in allowedParams) {
+    const imageFileData = handleImageFile(allowedParams.image_file);
+    return call_api('post', ['resources', 'visual_search'], {image_file: imageFileData}, callback, options);
+  }
   return call_api('get', ['resources', 'visual_search'], allowedParams, callback, options);
 };
 

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -6,10 +6,61 @@ const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
+const request = require('request');
 
-const { extend, includes, isEmpty } = utils;
+const {
+  extend,
+  includes,
+  isEmpty
+} = utils;
 
 const agent = config.api_proxy ? new https.Agent(config.api_proxy) : null;
+
+function requestWithUpload(uploadConfig, file, callback) {
+  const options = {
+    method: 'POST',
+    url: uploadConfig.api_url,
+    formData: {
+      image_file: file
+    },
+    ...(uploadConfig.auth.oauth_token && {headers: {'Authorization': `Bearer ${uploadConfig.auth.oauth_token}`}}),
+    ...(uploadConfig.auth.key && uploadConfig.auth.secret && {
+      auth: {
+        user: uploadConfig.auth.key,
+        pass: uploadConfig.auth.secret
+      }
+    })
+  };
+
+  if (typeof callback === "function") {
+    return request(options, (error, response, body) => {
+      if (error) {
+        return callback(error);
+      }
+      return callback({
+        statusCode: response.statusCode,
+        body: JSON.parse(body)
+      });
+    })
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(options, (error, response, body) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve({
+          statusCode: response.statusCode,
+          body: JSON.parse(body)
+        });
+      }
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
@@ -20,6 +71,13 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   let secret = auth.secret;
   let oauth_token = auth.oauth_token;
   let content_type = 'application/x-www-form-urlencoded';
+
+  if (params.image_file && method.toLowerCase() === 'post') {
+    return requestWithUpload({
+      api_url,
+      auth
+    }, params.image_file, callback);
+  }
 
   if (options.content_type === 'json') {
     query_params = JSON.stringify(params);
@@ -69,9 +127,13 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
     const {hide_sensitive = false} = config();
     const sanitizedOptions = {...request_options};
 
-    if (hide_sensitive === true){
-      if ("auth" in sanitizedOptions) { delete sanitizedOptions.auth; }
-      if ("Authorization" in sanitizedOptions.headers) { delete sanitizedOptions.headers.Authorization; }
+    if (hide_sensitive === true) {
+      if ("auth" in sanitizedOptions) {
+        delete sanitizedOptions.auth;
+      }
+      if ("Authorization" in sanitizedOptions.headers) {
+        delete sanitizedOptions.headers.Authorization;
+      }
     }
 
     if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
@@ -147,16 +209,16 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
     }
   };
 
-  const request = https.request(request_options, handle_response);
-  request.on("error", function (e) {
+  const req = https.request(request_options, handle_response);
+  req.on("error", function (e) {
     deferred.reject(e);
-    return typeof callback === "function" ? callback({ error: e }) : void 0;
+    return typeof callback === "function" ? callback({error: e}) : void 0;
   });
-  request.setTimeout(ensureOption(options, "timeout", 60000));
+  req.setTimeout(ensureOption(options, "timeout", 60000));
   if (method !== "GET") {
-    request.write(query_params);
+    req.write(query_params);
   }
-  request.end();
+  req.end();
   return deferred.promise;
 }
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "dependencies": {
     "cloudinary-core": "^2.13.0",
     "core-js": "^3.30.1",
+    "form-data": "^4.0.0",
     "lodash": "^4.17.21",
-    "q": "^1.5.1"
+    "q": "^1.5.1",
+    "request": "^2.88.2"
   },
   "devDependencies": {
+    "@types/expect.js": "^0.3.29",
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.5.0",
-    "@types/expect.js": "^0.3.29",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/test/integration/api/search/visual_search_spec.js
+++ b/test/integration/api/search/visual_search_spec.js
@@ -2,7 +2,8 @@ const helper = require('../../../spechelper');
 const cloudinary = require('../../../../cloudinary');
 const {
   strictEqual,
-  deepStrictEqual
+  deepStrictEqual,
+  throws
 } = require('assert');
 const {TEST_CLOUD_NAME} = require('../../../testUtils/testConstants');
 
@@ -17,7 +18,7 @@ describe('Visual search', () => {
     });
   });
 
-  it('should pass the image_url parameter to the api call', () => {
+  it('should pass the image_asset_id parameter to the api call', () => {
     return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
       cloudinary.v2.api.visual_search({image_asset_id: 'image-asset-id'});
 
@@ -27,13 +28,29 @@ describe('Visual search', () => {
     });
   });
 
-  it('should pass the image_url parameter to the api call', () => {
+  it('should pass the text parameter to the api call', () => {
     return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
       cloudinary.v2.api.visual_search({text: 'visual-search-input'});
 
       const [calledWithUrl] = requestSpy.firstCall.args;
       strictEqual(calledWithUrl.method, 'GET');
       strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/visual_search?text=visual-search-input`);
+    });
+  });
+
+  describe('with image_file', () => {
+    it('should allow uploading the file to get search results', async () => {
+      // todo: once migrated to DI, assert that image_file is passed, don't do actual http request
+      const searchResult = await cloudinary.v2.api.visual_search({image_file: `${__dirname}/../../../.resources/sample.jpg`});
+      deepStrictEqual(searchResult.statusCode, 200);
+    });
+
+    it('should throw an error if parameter is not a path or buffer', () => {
+      try {
+        cloudinary.v2.api.visual_search({image_file: 420})
+      } catch (error) {
+        strictEqual(error.message, 'image_file has to be either a path to file or a buffer');
+      }
     });
   });
 });

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -556,6 +556,16 @@ cloudinary.v2.api.visual_search({text: 'visual-search-input'}, function (error, 
 });
 
 // $ExpectType Promise<any>
+cloudinary.v2.api.visual_search({image_file: 'path/to/file'}, function (error, result) {
+    console.log(result);
+});
+
+// $ExpectType Promise<any>
+cloudinary.v2.api.visual_search({image_file: Buffer.from('abc')}, function (error, result) {
+    console.log(result);
+});
+
+// $ExpectType Promise<any>
 cloudinary.v2.api.transformation({width: 150, height: 100, crop: 'fill'},
     function (error, result) {
         console.log(result, error);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -410,7 +410,7 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
-    export type VisualSearchParams = { image_url: string } | { image_asset_id: string } | { text: string } | { image_file: string };
+    export type VisualSearchParams = { image_url: string } | { image_asset_id: string } | { text: string } | { image_file: string | Buffer };
 
     export interface ArchiveApiOptions {
         allow_missing?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -410,7 +410,7 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
-    export type VisualSearchParams = { image_url: string } | { image_asset_id: string } | { text: string };
+    export type VisualSearchParams = { image_url: string } | { image_asset_id: string } | { text: string } | { image_file: string };
 
     export interface ArchiveApiOptions {
         allow_missing?: boolean;


### PR DESCRIPTION
### Brief Summary of Changes
- new feature: visual search using file upload:
```javascript
cloudinary.v2.api.visual_search({image_file: 'path/to/file'}, function (error, result) {
    console.log(result);
});
```
or
```javascript
cloudinary.v2.api.visual_search({image_file: Buffer.from('abc')}, function (error, result) {
    console.log(result);
});
```
#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
I added the `requests` dependency because writing an http request with multi-part file upload using vanilla node is a complicated task and to be honest, I failed at that. I tried writing it from scratch and also reusing some components from the upload.js file but the way this sdk is designed does not allow reusing some of the functions there. At least not in an easy way that won't potentially mean a broken contract. Eventually, I'd prefer doing all http requests using an external library rather than avoiding adding it in the first place - to me, the cost of maintaining low level code is much higher than adding this single dependency.