### PR TITLE
fix: sending restrictions when creating or updating metadata fields

### DIFF
--- a/lib-es5/api.js
+++ b/lib-es5/api.js
@@ -634,7 +634,7 @@ exports.update_resources_access_mode_by_ids = function update_resources_access_m
 exports.add_metadata_field = function add_metadata_field(field, callback) {
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource", "restrictions");
   options.content_type = "json";
   return call_api("post", ["metadata_fields"], params, callback, options);
 };
@@ -709,7 +709,7 @@ exports.metadata_field_by_field_id = function metadata_field_by_field_id(externa
 exports.update_metadata_field = function update_metadata_field(external_id, field, callback) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
-  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  var params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource", "restrictions");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", external_id], params, callback, options);
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -488,7 +488,7 @@ exports.update_resources_access_mode_by_ids = function update_resources_access_m
  * @return {Object}
  */
 exports.add_metadata_field = function add_metadata_field(field, callback, options = {}) {
-  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource", "restrictions");
   options.content_type = "json";
   return call_api("post", ["metadata_fields"], params, callback, options);
 };
@@ -555,7 +555,7 @@ exports.metadata_field_by_field_id = function metadata_field_by_field_id(externa
  * @return {Object}
  */
 exports.update_metadata_field = function update_metadata_field(external_id, field, callback, options = {}) {
-  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource");
+  const params = pickOnlyExistingValues(field, "external_id", "type", "label", "mandatory", "default_value", "validation", "datasource", "restrictions");
   options.content_type = "json";
   return call_api("put", ["metadata_fields", external_id], params, callback, options);
 };


### PR DESCRIPTION
### Brief Summary of Changes
`restrictions` are forwarded to the api call when creating or updating metadata fields

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests
