### PR TITLE
fix: getUserAgent spec needs to match also prerelease versions

### DIFF
--- a/test/unit/cloudinaryUtils/getUserAgent.spec.js
+++ b/test/unit/cloudinaryUtils/getUserAgent.spec.js
@@ -12,6 +12,6 @@ describe("getUserAgent", function () {
   });
   it("should add a user platform to USER_AGENT", function () {
     cloudinary.utils.userPlatform = "Spec/1.0 (Test)";
-    expect(cloudinary.utils.getUserAgent()).to.match(/Spec\/1.0 \(Test\) CloudinaryNodeJS\/[\d.]+ \(Node [\d.]+\)/);
+    expect(cloudinary.utils.getUserAgent()).to.match(/Spec\/1.0 \(Test\) CloudinaryNodeJS\/[\d.]+(?:-[a-zA-Z\d]+)? \(Node [\d.]+\)/);
   });
 });


### PR DESCRIPTION
### Brief Summary of Changes
- `getUserAgent` didn't match a prerelase version number

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No