### PR TITLE
fix: fix error in analytics token

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -901,7 +901,8 @@ function url(public_id, options = {}) {
     let sdkVersions = {
       sdkCode: ensureOption(options, 'sdkCode', sdkCode),
       sdkSemver: ensureOption(options, 'sdkSemver', sdkSemver),
-      techVersion: ensureOption(options, 'techVersion', techVersion)
+      techVersion: ensureOption(options, 'techVersion', techVersion),
+      urlAnalytics
     };
 
     let analyticsOptions = getAnalyticsOptions(

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -26,6 +26,19 @@ describe('Tests for sdk analytics through image tag', function () {
     process.versions = processVersions;
   });
 
+  it('Can be turned off via options', () => {
+    process.versions = {
+      node: '12.0.0'
+    };
+
+    let imgStr = cloudinary.image("hello", {
+      format: "png",
+      urlAnalytics: false
+    });
+
+    expect(imgStr).not.to.contain(`MAlhAM0`);
+  });
+
   it('Defaults to true even if analytics is not passed as an option', () => {
     process.versions = {
       node: '12.0.0'

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -26,7 +26,7 @@ describe('Tests for sdk analytics through image tag', function () {
     process.versions = processVersions;
   });
 
-  it('Defaults to false if analytics is not passed as an option', () => {
+  it('Defaults to true even if analytics is not passed as an option', () => {
     process.versions = {
       node: '12.0.0'
     };
@@ -35,7 +35,7 @@ describe('Tests for sdk analytics through image tag', function () {
       format: "png"
     });
 
-    expect(imgStr).not.to.contain(`MAlhAM0`);
+    expect(imgStr).to.contain(`MAlhAM0`);
   });
 
   it('Reads from process.versions and package.json (Mocked)', () => {


### PR DESCRIPTION
### Brief Summary of Changes
After changing the default value of `urlAnalytics` in options to `true`, analytics token creation resulted in an error because of incomplete `options` object passed further into the internals. This PR correctly passes that value.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
