### PR TITLE
fix: getUserAgent regex

### DIFF
--- a/test/unit/cloudinaryUtils/getUserAgent.spec.js
+++ b/test/unit/cloudinaryUtils/getUserAgent.spec.js
@@ -12,6 +12,6 @@ describe("getUserAgent", function () {
   });
   it("should add a user platform to USER_AGENT", function () {
     cloudinary.utils.userPlatform = "Spec/1.0 (Test)";
-    expect(cloudinary.utils.getUserAgent()).to.match(/Spec\/1.0 \(Test\) CloudinaryNodeJS\/[\d.]+(?:-[a-zA-Z\d]+)? \(Node [\d.]+\)/);
+    expect(cloudinary.utils.getUserAgent()).to.match(/Spec\/1.0 \(Test\) CloudinaryNodeJS\/(\d+\.\d+\.\d+(?:-[\da-zA-Z]+(?:\.\d+)?)?) \(Node [\d.]+\)/);
   });
 });


### PR DESCRIPTION
### Brief Summary of Changes
Improved the regexp that tests the user agent header added to the requests. It should match all versions that are correct in term of semantic versioning, including prerelease modifiers and their versions.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
