### PR TITLE
fix: file and field encoding fixed for next production build

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -628,22 +628,22 @@ function post(url, post_data, boundary, file, callback, options) {
 
 function encodeFieldPart(boundary, name, value) {
   return [
-    `--${boundary}`,
-    `Content-Disposition: form-data; name="${name}"`,
-    '',
-    value,
+    `--${boundary}\r\n`,
+    `Content-Disposition: form-data; name="${name}"\r\n`,
+    '\r\n',
+    `${value}\r\n`,
     ''
-  ].join("\r\n");
+  ].join('');
 }
 
 function encodeFilePart(boundary, type, name, filename) {
   return [
-    `--${boundary}`,
-    `Content-Disposition: form-data; name="${name}"; filename="${filename}"`,
-    `Content-Type: ${type}`,
-    '',
+    `--${boundary}\r\n`,
+    `Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\n`,
+    `Content-Type: ${type}\r\n`,
+    '\r\n',
     ''
-  ].join("\r\n");
+  ].join('');
 }
 
 exports.direct_upload = function direct_upload(callback_url, options = {}) {


### PR DESCRIPTION
### Brief Summary of Changes
In next@14, production build stripped the strings from all `\r` characters which breaks manual (low-level) encoding of multipart file upload when using streams.

#### What Does This PR Address?
- [X] GitHub issue (Add reference - #650)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [X] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
