### PR TITLE
feat: notification-url for rename and destroy methods

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -205,7 +205,8 @@ exports.destroy = function destroy(public_id, callback, options = {}) {
         timestamp: utils.timestamp(),
         type: options.type,
         invalidate: options.invalidate,
-        public_id: public_id
+        public_id: public_id,
+        notification_url: options.notification_url
       }
     ];
   });
@@ -223,7 +224,8 @@ exports.rename = function rename(from_public_id, to_public_id, callback, options
         invalidate: options.invalidate,
         to_type: options.to_type,
         context: options.context,
-        metadata: options.metadata
+        metadata: options.metadata,
+        notification_url: options.notification_url
       }
     ];
   });

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -190,6 +190,12 @@ describe("uploader", function () {
       expect(renameResult).to.have.property('tags');
       expect(renameResult).to.have.property('context');
     });
+    it('should include notification_url in rename response if included in the request', async () => {
+      return helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
+        const renameResult = cloudinary.v2.uploader.rename('irrelevant', 'irrelevant', { notification_url: 'https://notification-url.com' });
+        sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher('notification_url', 'https://notification-url.com')));
+      });
+    });
     return context(":invalidate", function () {
       var spy, xhr;
       spy = void 0;
@@ -226,6 +232,12 @@ describe("uploader", function () {
         expect().fail();
       }).catch(function (error) {
         expect(error).to.be.ok();
+      });
+    });
+    it('should pass notification_url', async () => {
+      return helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
+        const renameResult = cloudinary.v2.uploader.destroy('irrelevant', { notification_url: 'https://notification-url.com' });
+        sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher('notification_url', 'https://notification-url.com')));
       });
     });
   });


### PR DESCRIPTION
### Brief Summary of Changes
Added `notification_url` support for `rename` and `destroy` in Upload API.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
