### PR TITLE
feat: added support for new api in beta - analyze api

### DIFF
--- a/lib/analysis/index.js
+++ b/lib/analysis/index.js
@@ -1,17 +1,30 @@
 const utils = require("../utils");
 const {call_analysis_api} = require('../api_client/call_analysis_api');
 
-function analyze(uri, analysis_type, options = {}, callback) {
-  let params = {
+function analyze_uri(uri, analysis_options, options = {}, callback) {
+  const analysisType = analysis_options.analysis_type;
+
+  const params = {
     uri,
-    analysis_type,
-    parameters: options.analyze_parameters
-  };
+    analysis_type: analysisType
+  }
+
+  if (analysisType === 'custom') {
+    if (!('model_name' in analysis_options) || !('model_version' in analysis_options)) {
+      throw new Error('Setting analysis_type to "custom" requires additional params: "model_name" and "model_version"');
+    }
+    params.parameters = {
+      custom: {
+        model_name: analysis_options.model_name,
+        model_version: analysis_options.model_version
+      }
+    }
+  }
 
   let api_uri = ['analysis', 'analyze', 'uri'];
   return call_analysis_api('POST', api_uri, params, callback, options);
 }
 
 module.exports = {
-  analyze
+  analyze_uri
 };

--- a/lib/analysis/index.js
+++ b/lib/analysis/index.js
@@ -1,22 +1,20 @@
 const utils = require("../utils");
 const {call_analysis_api} = require('../api_client/call_analysis_api');
 
-function analyze_uri(uri, analysis_options, options = {}, callback) {
-  const analysisType = analysis_options.analysis_type;
-
+function analyze_uri(uri, analysis_type, options = {}, callback) {
   const params = {
     uri,
-    analysis_type: analysisType
+    analysis_type
   }
 
-  if (analysisType === 'custom') {
-    if (!('model_name' in analysis_options) || !('model_version' in analysis_options)) {
+  if (analysis_type === 'custom') {
+    if (!('model_name' in options) || !('model_version' in options)) {
       throw new Error('Setting analysis_type to "custom" requires additional params: "model_name" and "model_version"');
     }
     params.parameters = {
       custom: {
-        model_name: analysis_options.model_name,
-        model_version: analysis_options.model_version
+        model_name: options.model_name,
+        model_version: options.model_version
       }
     }
   }

--- a/lib/analysis/index.js
+++ b/lib/analysis/index.js
@@ -1,0 +1,17 @@
+const utils = require("../utils");
+const {call_analysis_api} = require('../api_client/call_analysis_api');
+
+function analyze(uri, analysis_type, options = {}, callback) {
+  let params = {
+    uri,
+    analysis_type,
+    parameters: options.analyze_parameters
+  };
+
+  let api_uri = ['analysis', 'analyze', 'uri'];
+  return call_analysis_api('POST', api_uri, params, callback, options);
+}
+
+module.exports = {
+  analyze
+};

--- a/lib/api_client/call_analysis_api.js
+++ b/lib/api_client/call_analysis_api.js
@@ -24,13 +24,7 @@ function call_analysis_api(method, uri, params, callback, options) {
   }
   options.content_type = 'json';
 
-  return execute_request(method, params, auth, api_url, callback, options)
-    .then(requestResult => {
-      return {
-        data: requestResult.data,
-        request_id: requestResult.request_id
-      };
-    });
+  return execute_request(method, params, auth, api_url, callback, options);
 }
 
 module.exports = {

--- a/lib/api_client/call_analysis_api.js
+++ b/lib/api_client/call_analysis_api.js
@@ -1,0 +1,38 @@
+const utils = require("../utils");
+const config = require("../config");
+const ensureOption = require('../utils/ensureOption').defaults(config());
+const execute_request = require("./execute_request");
+
+const {ensurePresenceOf} = utils;
+
+function call_analysis_api(method, uri, params, callback, options) {
+  ensurePresenceOf({
+    method,
+    uri
+  });
+  const api_url = utils.base_api_url_v2()(uri, options);
+  let auth = {};
+  if (options.oauth_token || config().oauth_token) {
+    auth = {
+      oauth_token: ensureOption(options, "oauth_token")
+    };
+  } else {
+    auth = {
+      key: ensureOption(options, "api_key"),
+      secret: ensureOption(options, "api_secret")
+    };
+  }
+  options.content_type = 'json';
+
+  return execute_request(method, params, auth, api_url, callback, options)
+    .then(requestResult => {
+      return {
+        data: requestResult.data,
+        request_id: requestResult.request_id
+      };
+    });
+}
+
+module.exports = {
+  call_analysis_api
+};

--- a/lib/api_client/call_api.js
+++ b/lib/api_client/call_api.js
@@ -8,7 +8,7 @@ const { ensurePresenceOf } = utils;
 
 function call_api(method, uri, params, callback, options) {
   ensurePresenceOf({ method, uri });
-  const api_url = utils.base_api_url(uri, options);
+  const api_url = utils.base_api_url_v1()(uri, options);
   let auth = {};
   if (options.oauth_token || config().oauth_token){
     auth = {

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -99,9 +99,15 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         if (result.error) {
           result.error.http_code = res.statusCode;
         } else {
-          result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
-          result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
-          result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
+          if (res.headers["x-featureratelimit-limit"]) {
+            result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
+          }
+          if (res.headers["x-featureratelimit-reset"]) {
+            result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
+          }
+          if (res.headers["x-featureratelimit-remaining"]) {
+            result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
+          }
         }
 
         if (result.error) {

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -3,7 +3,9 @@ exports.config = require("./config");
 exports.utils = require("./utils");
 exports.uploader = require("./uploader");
 exports.api = require("./api");
-let account = require("./provisioning/account");
+exports.analysis = require('./analysis');
+
+const account = require("./provisioning/account");
 
 exports.provisioning = {
   account: account

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1058,17 +1058,31 @@ function unsigned_url_prefix(
   return prefix;
 }
 
-function base_api_url(path = [], options = {}) {
-  let cloudinary = ensureOption(options, "upload_prefix", UPLOAD_PREFIX);
-  let cloud_name = ensureOption(options, "cloud_name");
-  let encode_path = unencoded_path => encodeURIComponent(unencoded_path).replace("'", '%27');
-  let encoded_path = Array.isArray(path) ? path.map(encode_path) : encode_path(path);
-  return [cloudinary, "v1_1", cloud_name].concat(encoded_path).join("/");
+function base_api_url_v1() {
+  return base_api_url('v1_1');
+}
+
+function base_api_url_v2() {
+  return base_api_url('v2');
+}
+
+function base_api_url(api_version) {
+  if (!api_version || api_version.length === 0) {
+    throw new Error('api_version needs to be a non-empty string');
+  }
+
+  return (path = [], options = []) => {
+    let cloudinary = ensureOption(options, "upload_prefix", UPLOAD_PREFIX);
+    let cloud_name = ensureOption(options, "cloud_name");
+    let encode_path = unencoded_path => encodeURIComponent(unencoded_path).replace("'", '%27');
+    let encoded_path = Array.isArray(path) ? path.map(encode_path) : encode_path(path);
+    return [cloudinary, api_version, cloud_name].concat(encoded_path).join("/");
+  };
 }
 
 function api_url(action = 'upload', options = {}) {
   let resource_type = options.resource_type || "image";
-  return base_api_url([resource_type, action], options);
+  return base_api_url_v1()([resource_type, action], options);
 }
 
 function random_public_id() {
@@ -1225,7 +1239,7 @@ function download_backedup_asset(asset_id, version_id, options = {}) {
     asset_id: asset_id,
     version_id: version_id
   }, options);
-  return exports.base_api_url(['download_backup'], options) + "?" + hashToQuery(params);
+  return exports.base_api_url_v1()(['download_backup'], options) + "?" + hashToQuery(params);
 }
 
 /**
@@ -1681,7 +1695,8 @@ exports.only = pickOnlyExistingValues; // for backwards compatibility
 exports.pickOnlyExistingValues = pickOnlyExistingValues;
 exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
-exports.base_api_url = base_api_url;
+exports.base_api_url_v1 = base_api_url_v1;
+exports.base_api_url_v2 = base_api_url_v2;
 exports.download_backedup_asset = download_backedup_asset;
 exports.compute_hash = compute_hash;
 exports.build_distribution_domain = build_distribution_domain;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1058,7 +1058,7 @@ function unsigned_url_prefix(
   return prefix;
 }
 
-function base_api_url_v1() {
+function base_api_url_v1_1() {
   return base_api_url('v1_1');
 }
 
@@ -1082,7 +1082,7 @@ function base_api_url(api_version) {
 
 function api_url(action = 'upload', options = {}) {
   let resource_type = options.resource_type || "image";
-  return base_api_url_v1()([resource_type, action], options);
+  return base_api_url_v1_1()([resource_type, action], options);
 }
 
 function random_public_id() {
@@ -1695,7 +1695,7 @@ exports.only = pickOnlyExistingValues; // for backwards compatibility
 exports.pickOnlyExistingValues = pickOnlyExistingValues;
 exports.jsonArrayParam = jsonArrayParam;
 exports.download_folder = download_folder;
-exports.base_api_url_v1 = base_api_url_v1;
+exports.base_api_url_v1 = base_api_url_v1_1;
 exports.base_api_url_v2 = base_api_url_v2;
 exports.download_backedup_asset = download_backedup_asset;
 exports.compute_hash = compute_hash;

--- a/test/integration/api/analysis/analyze_spec.js
+++ b/test/integration/api/analysis/analyze_spec.js
@@ -1,0 +1,62 @@
+const sinon = require('sinon');
+const ClientRequest = require('_http_client').ClientRequest;
+const api_http = require('https');
+
+const cloudinary = require('../../../../cloudinary');
+const helper = require('../../../spechelper');
+
+describe('Analyze API', () => {
+  describe('uri analysis', () => {
+    const mocked = {};
+    const config = {};
+
+    beforeEach(function () {
+      mocked.xhr = sinon.useFakeXMLHttpRequest();
+      mocked.write = sinon.spy(ClientRequest.prototype, 'write');
+      mocked.request = sinon.spy(api_http, 'request');
+
+      config.cloud_name = cloudinary.config().cloud_name;
+    });
+
+    afterEach(function () {
+      mocked.request.restore();
+      mocked.write.restore();
+      mocked.xhr.restore();
+    });
+
+    it('should call analyze endpoint with non-custom analysis_type', () => {
+      cloudinary.analysis.analyze('https://example.com', 'captioning');
+
+      sinon.assert.calledWith(mocked.request, sinon.match({
+        pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),
+        method: sinon.match('POST')
+      }));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('uri', 'https://example.com')));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('analysis_type', 'captioning')));
+    });
+
+    it('should call analyze endpoint with custom analysis_type', () => {
+      cloudinary.analysis.analyze('https://example.com', 'custom', {
+        analyze_parameters: {
+          custom: {
+            model_name: 'custom_model',
+            model_version: 1
+          }
+        }
+      });
+
+      sinon.assert.calledWith(mocked.request, sinon.match({
+        pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),
+        method: sinon.match('POST')
+      }));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('uri', 'https://example.com')));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('analysis_type', 'custom')));
+      sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('parameters', {
+        custom: {
+          model_name: 'custom_model',
+          model_version: 1
+        }
+      })));
+    });
+  });
+});

--- a/test/integration/api/analysis/analyze_spec.js
+++ b/test/integration/api/analysis/analyze_spec.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const sinon = require('sinon');
 const ClientRequest = require('_http_client').ClientRequest;
 const api_http = require('https');
@@ -25,7 +26,9 @@ describe('Analyze API', () => {
     });
 
     it('should call analyze endpoint with non-custom analysis_type', () => {
-      cloudinary.analysis.analyze('https://example.com', 'captioning');
+      cloudinary.analysis.analyze_uri('https://example.com', {
+        analysis_type: 'captioning'
+      });
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),
@@ -36,13 +39,10 @@ describe('Analyze API', () => {
     });
 
     it('should call analyze endpoint with custom analysis_type', () => {
-      cloudinary.analysis.analyze('https://example.com', 'custom', {
-        analyze_parameters: {
-          custom: {
-            model_name: 'custom_model',
-            model_version: 1
-          }
-        }
+      cloudinary.analysis.analyze_uri('https://example.com', {
+        analysis_type: 'custom',
+        model_name: 'my_model',
+        model_version: 1
       });
 
       sinon.assert.calledWith(mocked.request, sinon.match({
@@ -53,10 +53,20 @@ describe('Analyze API', () => {
       sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('analysis_type', 'custom')));
       sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('parameters', {
         custom: {
-          model_name: 'custom_model',
+          model_name: 'my_model',
           model_version: 1
         }
       })));
+    });
+
+    it('should not allow calling analyze endpoint with incorrect custom analysis parameters', () => {
+      assert.throws(() => {
+        cloudinary.analysis.analyze_uri('https://example.com', {
+          analysis_type: 'custom'
+        })
+      }, {
+        message: 'Setting analysis_type to "custom" requires additional params: "model_name" and "model_version"'
+      });
     });
   });
 });

--- a/test/integration/api/analysis/analyze_spec.js
+++ b/test/integration/api/analysis/analyze_spec.js
@@ -26,9 +26,7 @@ describe('Analyze API', () => {
     });
 
     it('should call analyze endpoint with non-custom analysis_type', () => {
-      cloudinary.analysis.analyze_uri('https://example.com', {
-        analysis_type: 'captioning'
-      });
+      cloudinary.analysis.analyze_uri('https://example.com', 'captioning');
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),
@@ -39,8 +37,7 @@ describe('Analyze API', () => {
     });
 
     it('should call analyze endpoint with custom analysis_type', () => {
-      cloudinary.analysis.analyze_uri('https://example.com', {
-        analysis_type: 'custom',
+      cloudinary.analysis.analyze_uri('https://example.com', 'custom', {
         model_name: 'my_model',
         model_version: 1
       });
@@ -61,9 +58,7 @@ describe('Analyze API', () => {
 
     it('should not allow calling analyze endpoint with incorrect custom analysis parameters', () => {
       assert.throws(() => {
-        cloudinary.analysis.analyze_uri('https://example.com', {
-          analysis_type: 'custom'
-        })
+        cloudinary.analysis.analyze_uri('https://example.com', 'custom');
       }, {
         message: 'Setting analysis_type to "custom" requires additional params: "model_name" and "model_version"'
       });

--- a/test/utils/utils_spec.js
+++ b/test/utils/utils_spec.js
@@ -458,7 +458,7 @@ describe("utils", function () {
     });
     it('should escape api urls', function () {
       const folderName = "sub^folder's test";
-      const url = utils.base_api_url(['folders', folderName]);
+      const url = utils.base_api_url_v1()(['folders', folderName]);
       expect(url).to.match(/folders\/sub%5Efolder%27s%20test$/);
     });
   });

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -1148,6 +1148,15 @@ cloudinary.v2.provisioning.account.user_group_users(
 
     });
 
+// $ExpectType Promise<AnalyzeResponse>
+cloudinary.v2.analysis.analyze('https://example.com', 'custom', {
+    analyze_parameters: {
+        custom: {
+            model_name: 'my_model',
+            model_version: 1
+        }
+    }
+});
 
 // $ExpectType string
 cloudinary.v2.utils.private_download_url('foo', 'foo', {

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -1149,13 +1149,15 @@ cloudinary.v2.provisioning.account.user_group_users(
     });
 
 // $ExpectType Promise<AnalyzeResponse>
-cloudinary.v2.analysis.analyze('https://example.com', 'custom', {
-    analyze_parameters: {
-        custom: {
-            model_name: 'my_model',
-            model_version: 1
-        }
-    }
+cloudinary.v2.analysis.analyze_uri('https://example.com', {
+    analysis_type: 'captioning'
+});
+
+// $ExpectType Promise<AnalyzeResponse>
+cloudinary.v2.analysis.analyze_uri('https://example.com', {
+    analysis_type: 'custom',
+    model_name: 'my_name',
+    model_version: 1
 });
 
 // $ExpectType string

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -1149,13 +1149,10 @@ cloudinary.v2.provisioning.account.user_group_users(
     });
 
 // $ExpectType Promise<AnalyzeResponse>
-cloudinary.v2.analysis.analyze_uri('https://example.com', {
-    analysis_type: 'captioning'
-});
+cloudinary.v2.analysis.analyze_uri('https://example.com', 'captioning');
 
 // $ExpectType Promise<AnalyzeResponse>
-cloudinary.v2.analysis.analyze_uri('https://example.com', {
-    analysis_type: 'custom',
+cloudinary.v2.analysis.analyze_uri('https://example.com', 'custom', {
     model_name: 'my_name',
     model_version: 1
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -836,20 +836,9 @@ declare module 'cloudinary' {
         value: string;
     }
 
-    export type AnalysisType = CustomizableAnalysisType | NonCustomizableAnalysisType;
+    export type AnalysisType = 'custom' | 'captioning' | 'cld_fashion' | 'cld_text' | 'coco' | 'google_tagging' | 'human_anatomy' | 'lvis' | 'shop_classifier' | 'unidet';
 
-    export type CustomizableAnalysisType = 'custom';
-
-    export type NonCustomizableAnalysisType = 'captioning' | 'cld_fashion' | 'cld_text' | 'coco' | 'google_tagging' | 'human_anatomy' | 'lvis' | 'shop_classifier' | 'unidet';
-
-    export type AnalyzeOptions = NonCustomizableAnalyzeOptions | CustomizableAnalyzeOptions;
-
-    export interface NonCustomizableAnalyzeOptions {
-        analysis_type: NonCustomizableAnalysisType
-    }
-
-    export interface CustomizableAnalyzeOptions {
-        analysis_type: CustomizableAnalysisType,
+    export type CustomAnalysisOptions = {
         model_name: string,
         model_version: number
     }
@@ -1462,7 +1451,7 @@ declare module 'cloudinary' {
         }
 
         namespace analysis {
-            function analyze_uri(uri: string, analyze_options: AnalyzeOptions, options?: ConfigOptions): Promise<AnalyzeResponse>
+            function analyze_uri(uri: string, analysis_type: AnalysisType, options?: ConfigOptions & CustomAnalysisOptions): Promise<AnalyzeResponse>
         }
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -836,7 +836,23 @@ declare module 'cloudinary' {
         value: string;
     }
 
-    export type AnalysisType = 'captioning' | 'cld_fashion' | 'cld_text' | 'coco' | 'google_tagging' | 'human_anatomy' | 'lvis' | 'shop_classifier' | 'unidet' | 'custom';
+    export type AnalysisType = CustomizableAnalysisType | NonCustomizableAnalysisType;
+
+    export type CustomizableAnalysisType = 'custom';
+
+    export type NonCustomizableAnalysisType = 'captioning' | 'cld_fashion' | 'cld_text' | 'coco' | 'google_tagging' | 'human_anatomy' | 'lvis' | 'shop_classifier' | 'unidet';
+
+    export type AnalyzeOptions = NonCustomizableAnalyzeOptions | CustomizableAnalyzeOptions;
+
+    export interface NonCustomizableAnalyzeOptions {
+        analysis_type: NonCustomizableAnalysisType
+    }
+
+    export interface CustomizableAnalyzeOptions {
+        analysis_type: CustomizableAnalysisType,
+        model_name: string,
+        model_version: number
+    }
 
     export interface AnalyzeResponse {
         data: {
@@ -844,15 +860,6 @@ declare module 'cloudinary' {
             analysis: Record<string, Record<string, string> | Array<string> | string>
         },
         request_id: string,
-    }
-
-    export interface AnalyzeOptions {
-        analyze_parameters: {
-            custom: {
-                model_name: string,
-                model_version: number,
-            }
-        }
     }
 
     export namespace v2 {
@@ -1455,7 +1462,7 @@ declare module 'cloudinary' {
         }
 
         namespace analysis {
-            function analyze(uri: string, analysis_type: AnalysisType, options?: AnalyzeOptions & ConfigOptions): Promise<AnalyzeResponse>
+            function analyze_uri(uri: string, analyze_options: AnalyzeOptions, options?: ConfigOptions): Promise<AnalyzeResponse>
         }
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -836,6 +836,25 @@ declare module 'cloudinary' {
         value: string;
     }
 
+    export type AnalysisType = 'captioning' | 'cld_fashion' | 'cld_text' | 'coco' | 'google_tagging' | 'human_anatomy' | 'lvis' | 'shop_classifier' | 'unidet' | 'custom';
+
+    export interface AnalyzeResponse {
+        data: {
+            entity: string,
+            analysis: Record<string, Record<string, string> | Array<string> | string>
+        },
+        request_id: string,
+    }
+
+    export interface AnalyzeOptions {
+        analyze_parameters: {
+            custom: {
+                model_name: string,
+                model_version: number,
+            }
+        }
+    }
+
     export namespace v2 {
 
         /****************************** Global Utils *************************************/
@@ -1433,6 +1452,10 @@ declare module 'cloudinary' {
 
                 function user_group_users(groupId: string, options?: ProvisioningApiOptions, callback?: ResponseCallback): Promise<any>;
             }
+        }
+
+        namespace analysis {
+            function analyze(uri: string, analysis_type: AnalysisType, options?: AnalyzeOptions & ConfigOptions): Promise<AnalyzeResponse>
         }
     }
 }


### PR DESCRIPTION
### Brief Summary of Changes
Added support for new Analyze API (beta):
- new namespace added: `analysis`
  - one method available: `analyze_uri`
  - calls cloudinary api `v2`
  - should return immediately if used incorrectly (basic arguments check for vanilla js)

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [X] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
Please pay double attention to type descriptions available in *.d.ts files.
