### PR TITLE
Fix/metadata fields api response types

### DIFF
--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -654,6 +654,9 @@ cloudinary.v2.api.add_metadata_field({
 
 cloudinary.v2.api.list_metadata_fields().then((result) => {
     console.log(result.metadata_fields[0].datasource);
+    console.log(result.metadata_fields[0].datasource.values[0].value);
+    console.log(result.metadata_fields[0].datasource.values[0].external_id);
+    console.log(result.metadata_fields[0].datasource.values[0].state);
 });
 
 cloudinary.v2.api.delete_metadata_field('EXTERNAL_ID_GET_LIST').then((res) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -702,7 +702,9 @@ declare module 'cloudinary' {
         mandatory: boolean;
         default_value: number;
         validation: object; //there are 4 types, we need to discuss documentation team about it before implementing.
-        datasource: DatasourceEntry;
+        datasource: {
+            values: Array<DatasourceEntry>
+        };
 
         [futureKey: string]: any;
     }
@@ -830,11 +832,6 @@ declare module 'cloudinary' {
     }
 
     export type SignApiOptions = Record<string, any>;
-
-    export interface DatasourceEntry {
-        external_id?: string;
-        value: string;
-    }
 
     export namespace v2 {
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -713,6 +713,12 @@ declare module 'cloudinary' {
         metadata_fields: MetadataFieldApiResponse[]
     }
 
+    export interface DatasourceEntry {
+        external_id?: string;
+        value: string;
+        state?: 'active' | 'inactive'
+    }
+
     export interface DatasourceChange {
         values: Array<DatasourceEntry>
     }


### PR DESCRIPTION
### Brief Summary of Changes
- changed type of `MetadataFieldApiResponse.datasource` from `DatasourceChange` to `{ values: Array<DatasourceEntry> }`
- added `state` as an optional field for every `DatasourceEntry`

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
