### PR TITLE
feat: selective response for admin and search api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -71,7 +71,7 @@ exports.resources_by_moderation = function resources_by_moderation(kind, status,
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "moderations", kind, status];
-  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata", "fields", "fields"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata", "fields"), callback, options);
 };
 
 exports.resource_by_asset_id = function resource_by_asset_id(asset_id, callback, options = {}) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -45,21 +45,21 @@ exports.resources = function resources(callback, options = {}) {
   if ((options.start_at != null) && Object.prototype.toString.call(options.start_at) === '[object Date]') {
     options.start_at = options.start_at.toUTCString();
   }
-  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at", "metadata"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "prefix", "tags", "context", "direction", "moderations", "start_at", "metadata", "fields"), callback, options);
 };
 
 exports.resources_by_tag = function resources_by_tag(tag, callback, options = {}) {
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "tags", tag];
-  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata", "fields"), callback, options);
 };
 
 exports.resources_by_context = function resources_by_context(key, value, callback, options = {}) {
   let params, resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "context"];
-  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata", "fields");
   params.key = key;
   if (value != null) {
     params.value = value;
@@ -71,7 +71,7 @@ exports.resources_by_moderation = function resources_by_moderation(kind, status,
   let resource_type, uri;
   resource_type = options.resource_type || "image";
   uri = ["resources", resource_type, "moderations", kind, status];
-  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata"), callback, options);
+  return call_api("get", uri, pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "direction", "moderations", "metadata", "fields", "fields"), callback, options);
 };
 
 exports.resource_by_asset_id = function resource_by_asset_id(asset_id, callback, options = {}) {
@@ -82,7 +82,7 @@ exports.resource_by_asset_id = function resource_by_asset_id(asset_id, callback,
 exports.resources_by_asset_folder = function resources_by_asset_folder(asset_folder, callback, options = {}) {
   let params, uri;
   uri = ["resources", 'by_asset_folder'];
-  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "moderations");
+  params = pickOnlyExistingValues(options, "next_cursor", "max_results", "tags", "context", "moderations", "fields");
   params.asset_folder = asset_folder;
   return call_api("get", uri, params, callback, options);
 };
@@ -90,7 +90,7 @@ exports.resources_by_asset_folder = function resources_by_asset_folder(asset_fol
 exports.resources_by_asset_ids = function resources_by_asset_ids(asset_ids, callback, options = {}) {
   let params, uri;
   uri = ["resources", "by_asset_ids"];
-  params = pickOnlyExistingValues(options, "tags", "context", "moderations");
+  params = pickOnlyExistingValues(options, "tags", "context", "moderations", "fields");
   params["asset_ids[]"] = asset_ids;
   return call_api("get", uri, params, callback, options);
 }
@@ -100,7 +100,7 @@ exports.resources_by_ids = function resources_by_ids(public_ids, callback, optio
   resource_type = options.resource_type || "image";
   type = options.type || "upload";
   uri = ["resources", resource_type, type];
-  params = pickOnlyExistingValues(options, "tags", "context", "moderations");
+  params = pickOnlyExistingValues(options, "tags", "context", "moderations", "fields");
   params["public_ids[]"] = public_ids;
   return call_api("get", uri, params, callback, options);
 };

--- a/lib/v2/search.js
+++ b/lib/v2/search.js
@@ -15,7 +15,8 @@ const Search = class Search {
     this.query_hash = {
       sort_by: [],
       aggregate: [],
-      with_field: []
+      with_field: [],
+      fields: []
     };
     this._ttl = 300;
   }
@@ -42,6 +43,10 @@ const Search = class Search {
 
   static with_field(value) {
     return this.instance().with_field(value);
+  }
+
+  static fields(value) {
+    return this.instance().fields(value);
   }
 
   static sort_by(field_name, dir = 'asc') {
@@ -86,6 +91,16 @@ const Search = class Search {
 
     if (!found) {
       this.query_hash.with_field.push(value);
+    }
+
+    return this;
+  }
+
+  fields(value) {
+    const found = this.query_hash.fields.find(v => v === value);
+
+    if (!found) {
+      this.query_hash.fields.push(value);
     }
 
     return this;

--- a/lib/v2/search.js
+++ b/lib/v2/search.js
@@ -87,22 +87,24 @@ const Search = class Search {
   }
 
   with_field(value) {
-    const found = this.query_hash.with_field.find(v => v === value);
-
-    if (!found) {
+    if (Array.isArray(value)) {
+      this.query_hash.with_field = this.query_hash.with_field.concat(value);
+    } else {
       this.query_hash.with_field.push(value);
     }
 
+    this.query_hash.with_field = Array.from(new Set(this.query_hash.with_field));
     return this;
   }
 
   fields(value) {
-    const found = this.query_hash.fields.find(v => v === value);
-
-    if (!found) {
+    if (Array.isArray(value)) {
+      this.query_hash.fields = this.query_hash.fields.concat(value);
+    } else {
       this.query_hash.fields.push(value);
     }
 
+    this.query_hash.fields = Array.from(new Set(this.query_hash.fields));
     return this;
   }
 

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -429,30 +429,30 @@ describe("api", function () {
     });
 
     describe('selective response', () => {
-      const expectedKeys = ['public_id', 'asset_id', 'folder', 'tags'];
+      const expectedKeys = ['public_id', 'asset_id', 'folder', 'tags'].sort();
 
       it('should allow listing', async () => {
         const {resources} = await cloudinary.v2.api.resources({fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
 
       it('should allow listing by public_ids', async () => {
         const {resources} = await cloudinary.v2.api.resources_by_ids([PUBLIC_ID], {fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
 
       it('should allow listing by tag', async () => {
         const {resources} = await cloudinary.v2.api.resources_by_tag(TEST_TAG, {fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
 
       it('should allow listing by context', async () => {
         const {resources} = await cloudinary.v2.api.resources_by_context(contextKey, "test", {fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
 
       it('should allow listing by moderation', async () => {
@@ -462,14 +462,14 @@ describe("api", function () {
         });
         const {resources} = await cloudinary.v2.api.resources_by_moderation('manual', 'pending', {fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
 
       it('should allow listing by asset_ids', async () => {
         const {asset_id} = await uploadImage();
         const {resources} = await cloudinary.v2.api.resources_by_asset_ids([asset_id], {fields: ['tags']})
         const actualKeys = Object.keys(resources[0]);
-        assert.deepStrictEqual(actualKeys, expectedKeys);
+        assert.deepStrictEqual(actualKeys.sort(), expectedKeys);
       });
     });
   });

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -1577,5 +1577,26 @@ describe("api", function () {
         arg => arg.agent instanceof https.Agent
       ));
     });
-  })
+  });
+  describe('config hide_sensitive', () => {
+    it("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
+      try {
+        cloudinary.config({hide_sensitive: true});
+        const result = await cloudinary.v2.api.resource("?");
+        expect(result).fail();
+      } catch (err) {
+        expect(err.request_options).not.to.have.property("auth");
+      }
+    });
+
+    it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
+      try {
+        cloudinary.config({hide_sensitive: true});
+        const result = await cloudinary.v2.api.resource("?", { oauth_token: 'irrelevant' });
+        expect(result).fail();
+      } catch (err) {
+        expect(err.request_options.headers).not.to.have.property("Authorization");
+      }
+    });
+  });
 });

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -193,7 +193,7 @@ describe("search_api", function () {
             const additionallyIncluded = ['context'];
             const expectedKeys = [...alwaysIncluded, ...additionallyIncluded];
             const actualKeys = Object.keys(res);
-            assert.deepStrictEqual(actualKeys, expectedKeys);
+            assert.deepStrictEqual(actualKeys.sort(), expectedKeys.sort());
           });
         });
     });

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -5,6 +5,7 @@ const testConstants = require('../../../testUtils/testConstants');
 const describe = require('../../../testUtils/suite');
 const exp = require("constants");
 const cluster = require("cluster");
+const assert = require("assert");
 const {
   TIMEOUT,
   TAGS,
@@ -122,7 +123,7 @@ describe("search_api", function () {
         });
     });
 
-    it('Should eliminate duplicate fields when using sort_by, aggregate or with_fields', function () {
+    it('Should eliminate duplicate fields when using sort_by, aggregate, with_field or fields', function () {
       // This test ensures we can't push duplicate values into sort_by, aggregate or with_fields
       const search_query = cloudinary.v2.search.max_results(10).expression(`tags:${SEARCH_TAG}`)
         .sort_by('public_id', 'asc')
@@ -137,6 +138,9 @@ describe("search_api", function () {
         .with_field('foo')
         .with_field('foo')
         .with_field('foo2')
+        .fields('foo')
+        .fields('foo')
+        .fields('foo2')
         .to_query();
 
       expect(search_query.aggregate.length).to.be(2);
@@ -147,6 +151,8 @@ describe("search_api", function () {
       expect(search_query.aggregate[1]).to.be('foo2');
       expect(search_query.with_field[0]).to.be('foo');
       expect(search_query.with_field[1]).to.be('foo2');
+      expect(search_query.fields[0]).to.be('foo');
+      expect(search_query.fields[1]).to.be('foo2');
 
       expect(search_query.sort_by[0].public_id).to.be('desc');
     });
@@ -173,6 +179,21 @@ describe("search_api", function () {
             expect(Object.keys(res.context)).to.eql(['stage']);
             expect(res.image_metadata).to.be.ok();
             expect(res.tags.length).to.eql(4);
+          });
+        });
+    });
+
+    it('should only include selected keys when using fields', function () {
+      return cloudinary.v2.search.expression(`tags:${SEARCH_TAG}`).fields('context')
+        .execute()
+        .then(function (results) {
+          expect(results.resources.length).to.eql(3);
+          results.resources.forEach(function (res) {
+            const alwaysIncluded = ['public_id', 'asset_id', 'created_at', 'status', 'type', 'resource_type', 'folder'];
+            const additionallyIncluded = ['context'];
+            const expectedKeys = [...alwaysIncluded, ...additionallyIncluded];
+            const actualKeys = Object.keys(res);
+            assert.deepStrictEqual(actualKeys, expectedKeys);
           });
         });
     });

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -138,9 +138,11 @@ describe("search_api", function () {
         .with_field('foo')
         .with_field('foo')
         .with_field('foo2')
+        .with_field(['foo', 'foo2', 'foo3'])
         .fields('foo')
         .fields('foo')
         .fields('foo2')
+        .fields(['foo', 'foo2', 'foo3'])
         .to_query();
 
       expect(search_query.aggregate.length).to.be(2);
@@ -151,8 +153,10 @@ describe("search_api", function () {
       expect(search_query.aggregate[1]).to.be('foo2');
       expect(search_query.with_field[0]).to.be('foo');
       expect(search_query.with_field[1]).to.be('foo2');
+      expect(search_query.with_field[2]).to.be('foo3');
       expect(search_query.fields[0]).to.be('foo');
       expect(search_query.fields[1]).to.be('foo2');
+      expect(search_query.fields[2]).to.be('foo3');
 
       expect(search_query.sort_by[0].public_id).to.be('desc');
     });

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -146,7 +146,8 @@ describe("search_api", function () {
         .to_query();
 
       expect(search_query.aggregate.length).to.be(2);
-      expect(search_query.with_field.length).to.be(2);
+      expect(search_query.with_field.length).to.be(3);
+      expect(search_query.fields.length).to.be(3);
       expect(search_query.sort_by.length).to.be(1);
 
       expect(search_query.aggregate[0]).to.be('foo');

--- a/test/unit/config.spec.js
+++ b/test/unit/config.spec.js
@@ -30,26 +30,6 @@ describe("config", function () {
     expect(config.hide_sensitive).to.eql(true)
   });
 
-  it("should hide API key and secret upon error when `hide_sensitive` is true", async function () {
-    try {
-      cloudinary.config({hide_sensitive: true});
-      const result = await cloudinary.v2.api.resource("?");
-      expect(result).fail();
-    } catch (err) {
-      expect(err.request_options).not.to.have.property("auth");
-    }
-  });
-
-  it("should hide Authorization header upon error when `hide_sensitive` is true", async function () {
-    try {
-      cloudinary.config({hide_sensitive: true});
-      const result = await cloudinary.v2.api.resource("?", { oauth_token: 'irrelevant' });
-      expect(result).fail();
-    } catch (err) {
-      expect(err.request_options.headers).not.to.have.property("Authorization");
-    }
-  });
-
   it("should allow nested values in CLOUDINARY_URL", function () {
     process.env.CLOUDINARY_URL = "cloudinary://key:secret@test123?foo[bar]=value";
     cloudinary.config(true);

--- a/test/unit/search/search_spec.js
+++ b/test/unit/search/search_spec.js
@@ -63,16 +63,44 @@ describe('Search', () => {
   });
 
   it('should add with_field to query', function () {
-    var query = cloudinary.v2.search.with_field('context').with_field('tags').to_query();
+    const query = cloudinary.v2.search.with_field('context').with_field('tags').to_query();
     expect(query).to.eql({
       with_field: ['context', 'tags']
     });
   });
 
+  it('should allow adding multiple with_field values to query', function () {
+    const query = cloudinary.v2.search.with_field(['context', 'tags']).to_query();
+    expect(query).to.eql({
+      with_field: ['context', 'tags']
+    });
+  });
+
+  it('should remove duplicates with_field values from query', () => {
+    const query = cloudinary.v2.search.with_field(['field1', 'field1', 'field2']).to_query();
+    expect(query).to.eql({
+      with_field: ['field1', 'field2']
+    });
+  });
+
   it('should add fields to query', function () {
-    var query = cloudinary.v2.search.fields('context').fields('tags').to_query();
+    const query = cloudinary.v2.search.fields('context').fields('tags').to_query();
     expect(query).to.eql({
       fields: ['context', 'tags']
+    });
+  });
+
+  it('should allow adding multiple fields values to query', function () {
+    const query = cloudinary.v2.search.fields(['context', 'tags']).to_query();
+    expect(query).to.eql({
+      fields: ['context', 'tags']
+    });
+  });
+
+  it('should remove duplicates fields values from query', () => {
+    const query = cloudinary.v2.search.fields(['field1', 'field1', 'field2']).to_query();
+    expect(query).to.eql({
+      fields: ['field1', 'field2']
     });
   });
 

--- a/test/unit/search/search_spec.js
+++ b/test/unit/search/search_spec.js
@@ -15,7 +15,8 @@ describe('Search', () => {
       'max_results',
       'next_cursor',
       'aggregate',
-      'with_field'
+      'with_field',
+      'fields'
     ].forEach(method => expect(instance).to.eql(instance[method]('emptyarg')));
   });
 
@@ -65,6 +66,13 @@ describe('Search', () => {
     var query = cloudinary.v2.search.with_field('context').with_field('tags').to_query();
     expect(query).to.eql({
       with_field: ['context', 'tags']
+    });
+  });
+
+  it('should add fields to query', function () {
+    var query = cloudinary.v2.search.fields('context').fields('tags').to_query();
+    expect(query).to.eql({
+      fields: ['context', 'tags']
     });
   });
 

--- a/test/unit/search/search_spec.js
+++ b/test/unit/search/search_spec.js
@@ -77,9 +77,12 @@ describe('Search', () => {
   });
 
   it('should remove duplicates with_field values from query', () => {
-    const query = cloudinary.v2.search.with_field(['field1', 'field1', 'field2']).to_query();
+    const search = cloudinary.v2.search.with_field(['field1', 'field1', 'field2']);
+    search.with_field('field1');
+    search.with_field('field3');
+    const query = search.to_query();
     expect(query).to.eql({
-      with_field: ['field1', 'field2']
+      with_field: ['field1', 'field2', 'field3']
     });
   });
 
@@ -98,9 +101,12 @@ describe('Search', () => {
   });
 
   it('should remove duplicates fields values from query', () => {
-    const query = cloudinary.v2.search.fields(['field1', 'field1', 'field2']).to_query();
+    const search = cloudinary.v2.search.fields(['field1', 'field1', 'field2']);
+    search.fields('field1');
+    search.fields('field3');
+    const query = search.to_query();
     expect(query).to.eql({
-      fields: ['field1', 'field2']
+      fields: ['field1', 'field2', 'field3']
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1395,7 +1395,9 @@ declare module 'cloudinary' {
 
             to_query(value?: string): search;
 
-            with_field(value?: string): search;
+            with_field(value?: string | Array<string>): search;
+
+            fields(value?: string | Array<string>): search;
 
             to_url(newTtl?: number, next_cursor?: string, options?: ConfigOptions): string;
 
@@ -1413,7 +1415,9 @@ declare module 'cloudinary' {
 
             static ttl(newTtl: number): search;
 
-            static with_field(args?: string): search;
+            static with_field(args?: string | Array<string>): search;
+
+            static fields(args?: string | Array<string>): search;
         }
 
         /****************************** Provisioning API *************************************/


### PR DESCRIPTION
### Brief Summary of Changes
Support selective response for Admin and Search API: `fields` parameter is correctly added to requests supporting this parameter.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
