### PR TITLE
fix: remove dependency on Q

### DIFF
--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -6,14 +6,14 @@ const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
 
-const { extend, isEmpty } = utils;
+const { extend, isEmpty, includes } = utils;
 
 const agent = config.api_proxy ? new https.Agent(config.api_proxy) : null;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
 
-  let query_params, handle_response; // declare to use later
+  let query_params, handle_response; // declare to user later
   let key = auth.key;
   let secret = auth.secret;
   let oauth_token = auth.oauth_token;
@@ -74,7 +74,7 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
         if ("Authorization" in sanitizedOptions.headers) { delete sanitizedOptions.headers.Authorization; }
       }
 
-      if ([200, 400, 401, 403, 404, 409, 420, 500].includes(res.statusCode)) {
+      if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
         let buffer = "";
         let error = false;
         res.on("data", function (d) {

--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -2,20 +2,18 @@
 const config = require("../config");
 const https = /^http:/.test(config().upload_prefix) ? require('http') : require('https');
 const querystring = require("querystring");
-const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
 
-const { extend, includes, isEmpty } = utils;
+const { extend, isEmpty } = utils;
 
 const agent = config.api_proxy ? new https.Agent(config.api_proxy) : null;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
-  const deferred = Q.defer();
 
-  let query_params, handle_response; // declare to user later
+  let query_params, handle_response; // declare to use later
   let key = auth.key;
   let secret = auth.secret;
   let oauth_token = auth.oauth_token;
@@ -45,7 +43,7 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   if (oauth_token) {
     request_options.headers.Authorization = `Bearer ${oauth_token}`;
   } else {
-    request_options.auth = key + ":" + secret
+    request_options.auth = key + ":" + secret;
   }
 
   if (options.agent != null) {
@@ -65,105 +63,105 @@ function execute_request(method, params, auth, api_url, callback, options = {}) 
   if (method !== "GET") {
     request_options.headers['Content-Length'] = Buffer.byteLength(query_params);
   }
-  handle_response = function (res) {
-    const {hide_sensitive = false} = config();
-    const sanitizedOptions = {...request_options};
 
-    if (hide_sensitive === true){
-      if ("auth" in sanitizedOptions) { delete sanitizedOptions.auth; }
-      if ("Authorization" in sanitizedOptions.headers) { delete sanitizedOptions.headers.Authorization; }
-    }
+  return new Promise((resolve, reject) => {
+    handle_response = function (res) {
+      const { hide_sensitive = false } = config();
+      const sanitizedOptions = { ...request_options };
 
-    if (includes([200, 400, 401, 403, 404, 409, 420, 500], res.statusCode)) {
-      let buffer = "";
-      let error = false;
-      res.on("data", function (d) {
-        buffer += d;
-        return buffer;
-      });
-      res.on("end", function () {
-        let result;
-        if (error) {
-          return;
-        }
-        try {
-          result = JSON.parse(buffer);
-        } catch (e) {
-          result = {
+      if (hide_sensitive === true) {
+        if ("auth" in sanitizedOptions) { delete sanitizedOptions.auth; }
+        if ("Authorization" in sanitizedOptions.headers) { delete sanitizedOptions.headers.Authorization; }
+      }
+
+      if ([200, 400, 401, 403, 404, 409, 420, 500].includes(res.statusCode)) {
+        let buffer = "";
+        let error = false;
+        res.on("data", function (d) {
+          buffer += d;
+        });
+        res.on("end", function () {
+          let result;
+          if (error) {
+            return;
+          }
+          try {
+            result = JSON.parse(buffer);
+          } catch (e) {
+            result = {
+              error: {
+                message: "Server return invalid JSON response. Status Code " + res.statusCode
+              }
+            };
+          }
+
+          if (result.error) {
+            result.error.http_code = res.statusCode;
+            reject(Object.assign({
+              request_options: sanitizedOptions,
+              query_params
+            }, result));
+          } else {
+            if (res.headers["x-featureratelimit-limit"]) {
+              result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
+            }
+            if (res.headers["x-featureratelimit-reset"]) {
+              result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
+            }
+            if (res.headers["x-featureratelimit-remaining"]) {
+              result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
+            }
+            resolve(result);
+          }
+
+          if (typeof callback === "function") {
+            callback(result);
+          }
+        });
+        res.on("error", function (e) {
+          error = true;
+          let err_obj = {
             error: {
-              message: "Server return invalid JSON response. Status Code " + res.statusCode
+              message: e,
+              http_code: res.statusCode,
+              request_options: sanitizedOptions,
+              query_params
             }
           };
-        }
-
-        if (result.error) {
-          result.error.http_code = res.statusCode;
-        } else {
-          if (res.headers["x-featureratelimit-limit"]) {
-            result.rate_limit_allowed = parseInt(res.headers["x-featureratelimit-limit"]);
+          reject(err_obj.error);
+          if (typeof callback === "function") {
+            callback(err_obj);
           }
-          if (res.headers["x-featureratelimit-reset"]) {
-            result.rate_limit_reset_at = new Date(res.headers["x-featureratelimit-reset"]);
-          }
-          if (res.headers["x-featureratelimit-remaining"]) {
-            result.rate_limit_remaining = parseInt(res.headers["x-featureratelimit-remaining"]);
-          }
-        }
-
-        if (result.error) {
-          deferred.reject(Object.assign({
-            request_options: sanitizedOptions,
-            query_params
-          }, result));
-        } else {
-          deferred.resolve(result);
-        }
-        if (typeof callback === "function") {
-          callback(result);
-        }
-      });
-      res.on("error", function (e) {
-        error = true;
+        });
+      } else {
         let err_obj = {
           error: {
-            message: e,
+            message: "Server returned unexpected status code - " + res.statusCode,
             http_code: res.statusCode,
             request_options: sanitizedOptions,
             query_params
           }
         };
-        deferred.reject(err_obj.error);
+        reject(err_obj.error);
         if (typeof callback === "function") {
           callback(err_obj);
         }
-      });
-    } else {
-      let err_obj = {
-        error: {
-          message: "Server returned unexpected status code - " + res.statusCode,
-          http_code: res.statusCode,
-          request_options: sanitizedOptions,
-          query_params
-        }
-      };
-      deferred.reject(err_obj.error);
-      if (typeof callback === "function") {
-        callback(err_obj);
       }
-    }
-  };
+    };
 
-  const request = https.request(request_options, handle_response);
-  request.on("error", function (e) {
-    deferred.reject(e);
-    return typeof callback === "function" ? callback({ error: e }) : void 0;
+    const request = https.request(request_options, handle_response);
+    request.on("error", function (e) {
+      reject(e);
+      if (typeof callback === "function") {
+        callback({ error: e });
+      }
+    });
+    request.setTimeout(ensureOption(options, "timeout", 60000));
+    if (method !== "GET") {
+      request.write(query_params);
+    }
+    request.end();
   });
-  request.setTimeout(ensureOption(options, "timeout", 60000));
-  if (method !== "GET") {
-    request.write(query_params);
-  }
-  request.end();
-  return deferred.promise;
 }
 
 module.exports = execute_request;

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const { extname, basename } = require('path');
-const Q = require('q');
 const Writable = require("stream").Writable;
 const urlLib = require('url');
 
@@ -462,61 +461,64 @@ function call_api(action, callback, options, get_params) {
     callback = function () {};
   }
 
-  const USE_PROMISES = !options.disable_promises;
-
-  let deferred = Q.defer();
   if (options == null) {
     options = {};
   }
+
+  const USE_PROMISES = !options.disable_promises;
+
   let [params, unsigned_params, file] = get_params.call();
   params = utils.process_request_params(params, options);
   params = extend(params, unsigned_params);
   let api_url = utils.api_url(action, options);
   let boundary = utils.random_public_id();
   let errorRaised = false;
+
   let handle_response = function (res) {
-    // let buffer;
     if (errorRaised) {
-
       // Already reported
-    } else if (res.error) {
-      errorRaised = true;
+      return;
+    }
 
+    if (res.error) {
+      errorRaised = true;
       if (USE_PROMISES) {
-        deferred.reject(res);
+        return Promise.reject(res);
+      } else {
+        callback(res);
       }
-      callback(res);
-    } else if (includes([200, 400, 401, 404, 420, 500], res.statusCode)) {
+    } else if ([200, 400, 401, 404, 420, 500].includes(res.statusCode)) {
       let buffer = "";
       res.on("data", (d) => {
         buffer += d;
-        return buffer;
       });
       res.on("end", () => {
-        let result;
-        if (errorRaised) {
-          return;
-        }
-        result = parseResult(buffer, res);
+        if (errorRaised) return;
+
+        let result = parseResult(buffer, res);
         if (result.error) {
           result.error.http_code = res.statusCode;
           if (USE_PROMISES) {
-            deferred.reject(result.error);
+            return Promise.reject(result.error);
+          } else {
+            callback(result);
           }
         } else {
           cacheResults(result, options);
           if (USE_PROMISES) {
-            deferred.resolve(result);
+            return Promise.resolve(result);
+          } else {
+            callback(result);
           }
         }
-        callback(result);
       });
       res.on("error", (error) => {
         errorRaised = true;
         if (USE_PROMISES) {
-          deferred.reject(error);
+          return Promise.reject(error);
+        } else {
+          callback({ error });
         }
-        callback({ error });
       });
     } else {
       let error = {
@@ -525,23 +527,63 @@ function call_api(action, callback, options, get_params) {
         name: "UnexpectedResponse"
       };
       if (USE_PROMISES) {
-        deferred.reject(error);
+        return Promise.reject(error);
+      } else {
+        callback({ error });
       }
-      callback({ error });
     }
   };
+
   let post_data = utils.hashToParameters(params)
     .filter(([key, value]) => value != null)
     .map(
       ([key, value]) => Buffer.from(encodeFieldPart(boundary, key, value), 'utf8')
     );
+
   let result = post(api_url, post_data, boundary, file, handle_response, options);
   if (isObject(result)) {
     return result;
   }
 
   if (USE_PROMISES) {
-    return deferred.promise;
+    return new Promise((resolve, reject) => {
+      handle_response = function (res) {
+        if (errorRaised) return;
+
+        if (res.error) {
+          errorRaised = true;
+          reject(res);
+        } else if ([200, 400, 401, 404, 420, 500].includes(res.statusCode)) {
+          let buffer = "";
+          res.on("data", (d) => {
+            buffer += d;
+          });
+          res.on("end", () => {
+            if (errorRaised) return;
+
+            let currentResult = parseResult(buffer, res);
+            if (currentResult.error) {
+              currentResult.error.http_code = res.statusCode;
+              reject(currentResult.error);
+            } else {
+              cacheResults(currentResult, options);
+              resolve(currentResult);
+            }
+          });
+          res.on("error", (error) => {
+            errorRaised = true;
+            reject(error);
+          });
+        } else {
+          let error = {
+            message: `Server returned unexpected status code - ${res.statusCode}`,
+            http_code: res.statusCode,
+            name: "UnexpectedResponse"
+          };
+          reject(error);
+        }
+      };
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
   },
   "main": "cloudinary.js",
   "dependencies": {
-    "lodash": "^4.17.21",
-    "q": "^1.5.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@types/expect.js": "^0.3.29",
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.5.0",
-    "@types/expect.js": "^0.3.29",
     "date-fns": "^2.16.1",
     "dotenv": "4.x",
     "dtslint": "^0.9.1",

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -3,7 +3,6 @@ const formatDate = require("date-fns").format;
 const subDate = require("date-fns").sub;
 const https = require('https');
 const ClientRequest = require('_http_client').ClientRequest;
-const Q = require('q');
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
 const describe = require('../../../testUtils/suite');
@@ -102,7 +101,7 @@ describe("api", function () {
       default_value: METADATA_DEFAULT_VALUE
     });
 
-    await Q.all([
+    await Promise.all([
       uploadImage({
         public_id: PUBLIC_ID,
         tags: UPLOAD_TAGS,
@@ -138,7 +137,7 @@ describe("api", function () {
     if (!(config.api_key && config.api_secret)) {
       expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
     }
-    return Q.allSettled([
+    return Promise.allSettled([
       cloudinary.v2.api.delete_metadata_field(METADATA_EXTERNAL_ID),
       cloudinary.v2.api.delete_resources_by_tag(TEST_TAG),
       cloudinary.v2.api.delete_upload_preset(API_TEST_UPLOAD_PRESET1),
@@ -352,7 +351,7 @@ describe("api", function () {
     });
     it("should allow listing resources specifying direction", function () {
       this.timeout(TIMEOUT.LONG);
-      Q.all(
+      Promise.all(
         cloudinary.v2.api.resources_by_tag(TEST_TAG, {
           type: "upload",
           max_results: 500,
@@ -532,7 +531,7 @@ describe("api", function () {
     });
     it("should allow deleting derived resources by transformations", function () {
       this.timeout(TIMEOUT.LARGE);
-      return Q.all([
+      return Promise.all([
         uploadImage({
           public_id: PUBLIC_ID_1,
           tags: UPLOAD_TAGS,
@@ -671,7 +670,7 @@ describe("api", function () {
     callReusableTest("a list with a cursor", cloudinary.v2.api.transformations);
     transformationName = "api_test_transformation3" + UNIQUE_JOB_SUFFIX_ID;
     after(function () {
-      return Q.allSettled(
+      return Promise.allSettled(
         [
           cloudinary.v2.api.delete_transformation(transformationName),
           cloudinary.v2.api.delete_transformation(NAMED_TRANSFORMATION),
@@ -1110,7 +1109,7 @@ describe("api", function () {
     // Replace `it` with  `it.skip` below if you want to disable it.
     it("should list folders in cloudinary", function () {
       this.timeout(TIMEOUT.LONG);
-      return Q.all([
+      return Promise.all([
         uploadImage({
           public_id: 'test_folder1/item',
           tags: UPLOAD_TAGS
@@ -1133,7 +1132,7 @@ describe("api", function () {
         })
       ]).then(wait(TIMEOUT.SHORT))
         .then(function (results) {
-          return Q.all([cloudinary.v2.api.root_folders(), cloudinary.v2.api.sub_folders('test_folder1')]);
+          return Promise.all([cloudinary.v2.api.root_folders(), cloudinary.v2.api.sub_folders('test_folder1')]);
         }).then(function (results) {
           var folder, root, root_folders, sub_1;
           root = results[0];

--- a/test/integration/api/admin/structured_metadata_spec.js
+++ b/test/integration/api/admin/structured_metadata_spec.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const Q = require('q');
 const sinon = require('sinon');
 const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
@@ -95,7 +94,7 @@ describe("structured metadata api", function () {
 
   before(function () {
     // Create the metadata fields required for the tests
-    return Q.allSettled(
+    return Promise.allSettled(
       metadata_fields_to_create.map(field => createMetadataFieldForTest(field))
     ).finally(function () {
     });
@@ -103,7 +102,7 @@ describe("structured metadata api", function () {
 
   after(function () {
     // Delete all metadata fields created during testing
-    return Q.allSettled(
+    return Promise.allSettled(
       metadata_fields_external_ids.map(field => api.delete_metadata_field(field))
     ).finally(function () {
     });

--- a/test/integration/api/search/search_spec.js
+++ b/test/integration/api/search/search_spec.js
@@ -1,10 +1,7 @@
-const Q = require('q');
 const cloudinary = require('../../../../cloudinary');
 const helper = require("../../../spechelper");
 const testConstants = require('../../../testUtils/testConstants');
 const describe = require('../../../testUtils/suite');
-const exp = require("constants");
-const cluster = require("cluster");
 const assert = require("assert");
 const {
   TIMEOUT,
@@ -30,7 +27,7 @@ describe("search_api", function () {
   describe("integration", function () {
     this.timeout(TIMEOUT.LONG);
     before(function () {
-      return Q.allSettled([
+      return Promise.allSettled([
         cloudinary.v2.uploader.upload(helper.IMAGE_FILE,
           {
             public_id: PUBLIC_ID_1,

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -2,7 +2,6 @@ const https = require('https');
 const last = require('lodash/last');
 const sinon = require("sinon");
 const execSync = require('child_process').execSync;
-const Q = require('q');
 const fs = require('fs');
 const os = require('os');
 const describe = require('../../../testUtils/suite');
@@ -43,7 +42,7 @@ describe("archive", function () {
   this.timeout(TIMEOUT.LONG);
 
   before(function () {
-    return Q.all([
+    return Promise.all([
       uploader.upload(IMAGE_URL,
         {
           public_id: PUBLIC_ID1,

--- a/test/integration/api/uploader/slideshow_spec.js
+++ b/test/integration/api/uploader/slideshow_spec.js
@@ -1,4 +1,3 @@
-const Q = require('q');
 const cloudinary = require("../../../../cloudinary");
 const describe = require('../../../testUtils/suite');
 const TEST_ID = Date.now();
@@ -26,7 +25,7 @@ describe("create slideshow tests", function () {
     if (!(config.api_key && config.api_secret)) {
       expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
     }
-    return Q.allSettled([
+    return Promise.allSettled([
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG) : void 0,
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG,
         {

--- a/test/integration/api/uploader/uploader_spec.js
+++ b/test/integration/api/uploader/uploader_spec.js
@@ -2,9 +2,9 @@ const https = require('https');
 const http = require('http');
 const sinon = require('sinon');
 const fs = require('fs');
-const Q = require('q');
 const path = require('path');
 const at = require('lodash/at');
+const { promisify } = require('util')
 const uniq = require('lodash/uniq');
 const ClientRequest = require('_http_client').ClientRequest;
 const cloudinary = require("../../../../cloudinary");
@@ -57,7 +57,7 @@ describe("uploader", function () {
     if (!(config.api_key && config.api_secret)) {
       expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
     }
-    return Q.allSettled([
+    return Promise.allSettled([
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG) : void 0,
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG,
         {
@@ -425,7 +425,7 @@ describe("uploader", function () {
   describe("context", function () {
     this.timeout(TIMEOUT.MEDIUM);
     before(function () {
-      return Q.all([uploadImage(), uploadImage()]).spread((result1, result2) => {
+      return Promise.all([uploadImage(), uploadImage()]).spread((result1, result2) => {
         this.first_id = result1.public_id;
         this.second_id = result2.public_id;
       });
@@ -791,7 +791,7 @@ describe("uploader", function () {
       writeSpy = sinon.spy(ClientRequest.prototype, 'write');
       stat = fs.statSync(LARGE_VIDEO);
       expect(stat).to.be.ok();
-      return Q.denodeify(cloudinary.v2.uploader.upload_chunked)(LARGE_VIDEO, {
+      return promisify(cloudinary.v2.uploader.upload_chunked)(LARGE_VIDEO, {
         chunk_size: 6000000,
         resource_type: 'video',
         timeout: TIMEOUT.LONG * 10,
@@ -815,7 +815,7 @@ describe("uploader", function () {
     });
     it("should update timestamp for each chunk", function () {
       var writeSpy = sinon.spy(ClientRequest.prototype, 'write');
-      return Q.denodeify(cloudinary.v2.uploader.upload_chunked)(LARGE_VIDEO, {
+      return promisify(cloudinary.v2.uploader.upload_chunked)(LARGE_VIDEO, {
         chunk_size: 6000000,
         resource_type: 'video',
         timeout: TIMEOUT.LONG * 10,
@@ -1385,7 +1385,7 @@ describe("uploader", function () {
       let resource_1;
       let resource_2;
 
-      return Q.allSettled(
+      return Promise.allSettled(
         [
           uploadImage({
             tags: UPLOAD_TAGS

--- a/test/integration/streaming_profiles_spec.js
+++ b/test/integration/streaming_profiles_spec.js
@@ -1,6 +1,5 @@
 let describe = require('../testUtils/suite');
 const keys = require('lodash/keys');
-const Q = require('q');
 const cloudinary = require("../../cloudinary");
 const helper = require("../spechelper");
 const TIMEOUT = require('../testUtils/testConstants').TIMEOUT;
@@ -17,9 +16,9 @@ describe('Cloudinary::Api', function () {
   after(function () {
     cloudinary.config(true);
     if (cloudinary.config().keep_test_products) {
-      return Q.resolve();
+      return Promise.resolve();
     }
-    return Q.allSettled([
+    return Promise.allSettled([
       cloudinary.v2.api.delete_streaming_profile(test_id_1),
       cloudinary.v2.api.delete_streaming_profile(test_id_1 + 'a'),
       cloudinary.v2.api.delete_streaming_profile(test_id_3)

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -2,7 +2,6 @@ const isFunction = require('lodash/isFunction');
 const querystring = require('querystring');
 const sinon = require('sinon');
 const ClientRequest = require('_http_client').ClientRequest;
-const Q = require('q');
 const http = require('http');
 const https = require('https');
 // Load all our custom assertions
@@ -235,7 +234,7 @@ A test block
 exports.provideMockObjects = function (providedFunction) {
   let requestSpy, writeSpy, mockXHR;
 
-  return Q.Promise(function (resolve, reject, notify) {
+  return new Promise(function (resolve, reject) {
     var result;
 
     mockXHR = sinon.useFakeXMLHttpRequest();

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -253,7 +253,7 @@ exports.provideMockObjects = function (providedFunction) {
     requestSpy.restore();
     writeSpy.restore();
     mockXHR.restore();
-  }).done();
+  });
 };
 
 exports.setupCache = function () {


### PR DESCRIPTION
### Brief Summary of Changes

This PR removes a deprecated and outdated Promise library - Q. And replaces it with Promise API and built-ins.

[deprecation notice](https://www.npmjs.com/package/cloudinary) from q:

> You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other. (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)

The source now uses the following methods:

- `new Promise()` - supported since Node 0.12 and in all browsers (except IE11)
- `Promise.resolve` - same as above
- `Promise.reject` - same as above

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No, the tests logic didn't change
