### PR TITLE
Add `update_partial_overrides` method to the API

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -692,3 +692,8 @@ exports.update_metadata_rule = function update_metadata_rule(field_external_id, 
 exports.delete_metadata_rule = function delete_metadata_rule(field_external_id, callback, options = {}) {
   return call_api('delete', ['metadata_rules', field_external_id], {}, callback, options);
 };
+
+exports.update_partial_overrides = function update(asset_id, callback, params) {
+  const uri = ["resources", asset_id, "partial_overrides"];
+  return call_api("put", uri, params, callback, {content_type: 'json'});
+};

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -1,3 +1,5 @@
+
+
 const api = require('../api');
 const v1_adapters = require('../utils').v1_adapters;
 
@@ -74,5 +76,6 @@ v1_adapters(exports, api, {
   add_related_assets: 2,
   add_related_assets_by_asset_id: 2,
   delete_related_assets: 2,
-  delete_related_assets_by_asset_id: 2
+  delete_related_assets_by_asset_id: 2,
+  update_partial_overrides: 1
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "types": "types",
   "scripts": {
     "test": "tools/scripts/test.sh",
-    "test:unit": "tools/scripts/test.es6.unit.sh",
+    "test:unit": "CLOUDINARY_URL=cloudinary://xxxx tools/scripts/test.es6.unit.sh",
     "test-with-temp-cloud": "tools/scripts/tests-with-temp-cloud.sh",
     "dtslint": "tools/scripts/ditslint.sh",
     "lint": "tools/scripts/lint.sh",

--- a/test/integration/api/admin/api_spec.js
+++ b/test/integration/api/admin/api_spec.js
@@ -1599,4 +1599,24 @@ describe("api", function () {
       }
     });
   });
+  describe('update_partial_overrides', () => {
+    it("should call the PUT /resources/:asset_id/partial_overrides endpoint", async () => {
+      this.timeout(TIMEOUT.LONG);
+      await retry(async function () {
+        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+          cloudinary.v2.api.update_partial_overrides('ASSET_ID_MOCK', {
+            transformation_prefix: 'tx_prefix',
+            asset_override_uri: 'snapshot_url',
+            overrides: [{ action: 'gen_fill', params: { seed: 'seed', prompt: 'prompt', ignore_foreground: true } }]
+          });
+          sinon.assert.calledWith(writeSpy, sinon.match(helper.apiParamMatcher('transformation_prefix', 'tx_prefix')));
+          sinon.assert.calledWith(writeSpy, sinon.match(helper.apiParamMatcher('asset_override_uri', 'snapshot_url')));
+          return sinon.assert.calledWith(requestSpy, sinon.match({
+            pathname: sinon.match("resources/ASSET_ID_MOCK/partial_overrides"),
+            method: sinon.match("PUT")
+          }));
+        });
+      });
+    });
+  })
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -500,6 +500,19 @@ declare module 'cloudinary' {
         [futureKey: string]: any;
     }
 
+    export interface UpdatePartialOverridesOptions {
+        transformation_prefix: string;
+        asset_override_uri: string;
+        overrides: Array<{
+            action: 'gen_fill';
+            params: {
+                seed: string;
+                prompt: string;
+                ignore_foreground: boolean;
+            }
+        }>;
+    }
+
     export interface UploadApiOptions {
         access_mode?: AccessMode;
         allowed_formats?: Array<VideoFormat> | Array<ImageFormat>;
@@ -1214,6 +1227,10 @@ declare module 'cloudinary' {
             function restore_metadata_field_datasource(field_external_id: string, entries_external_id: string[], options?: AdminApiOptions, callback?: ResponseCallback): Promise<DatasourceChange>;
 
             function restore_metadata_field_datasource(field_external_id: string, entries_external_id: string[], callback?: ResponseCallback): Promise<DatasourceChange>;
+
+            function update_partial_overrides(public_id: string, options: UpdatePartialOverridesOptions, callback?: ResponseCallback): Promise<any>;
+
+            function update_partial_overrides(public_id: string, callback?: ResponseCallback): Promise<any>;
 
             /****************************** Structured Metadata Rules API V2 Methods *************************************/
             function add_metadata_rule(rule: MetadataRule, options?: AdminApiOptions, callback?: ResponseCallback): Promise<MetadataRuleResponse>;


### PR DESCRIPTION
### Brief Summary of Changes
- Add `update_partial_overrides` method to the API. This will allow to override `gen_fill` derived asset result.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
