### PR TITLE
Lock jsdoc version to fix deps lint error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-import": "^2.20.2",
     "expect.js": "0.3.x",
     "glob": "^7.1.6",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "3.5.5",
     "jsdom": "^9.12.0",
     "jsdom-global": "2.1.1",
     "mocha": "^6.2.3",


### PR DESCRIPTION
### Brief Summary of Changes
There's `jsdoc ^3.5.5` in package json. Because of the caret, currently installed version is 3.6.11. This newer version contains the `markdown-it` and `@types/markdown-it` packages, and the latter one gives an dtslint error in the CI:

```
> cloudinary@2.2.0 dtslint /home/travis/build/cloudinary/cloudinary_npm
> tools/scripts/ditslint.sh
Error: Errors in typescript@local for external dependencies:
../node_modules/@types/markdown-it/lib/index.d.ts(151,33): error TS2694: Namespace 'LinkifyIt' has no exported member 'LinkifyIt'.
    at /home/travis/build/cloudinary/cloudinary_npm/node_modules/dtslint/bin/index.js:190:19
    at Generator.next (<anonymous>)
    at fulfilled (/home/travis/build/cloudinary/cloudinary_npm/node_modules/dtslint/bin/index.js:5:58)
```

Locking the `jsdoc` version to exact 3.5.5 helps CI to pass successfully.

Maybe there's another, better solution than downgrading `jsdoc` package (e.g. upgrading it to 4.x version; in general, many packages used here are outdated, also `dtslint`), but for the time being this fix seems to be a quick, safe and working solution. 

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
