### PR TITLE
Fix/url analytics property name

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -894,20 +894,25 @@ function url(public_id, options = {}) {
     resultUrl += `?${token}`;
   }
 
-  let urlAnalytics = ensureOption(options, 'urlAnalytics', true);
+  const urlAnalytics = ensureOption(options, 'urlAnalytics', ensureOption(options, 'analytics', true));
 
   if (urlAnalytics === true) {
     let {
-      sdkCode,
-      sdkSemver,
-      techVersion,
-      product
+      sdkCode: sdkCodeDefault,
+      sdkSemver: sdkSemverDefault,
+      techVersion: techVersionDefault,
+      product: productDefault
     } = getSDKVersions();
+    const sdkCode = ensureOption(options, 'sdkCode', ensureOption(options, 'sdk_code', sdkCodeDefault));
+    const sdkSemver = ensureOption(options, 'sdkSemver', ensureOption(options, 'sdk_semver', sdkSemverDefault));
+    const techVersion = ensureOption(options, 'techVersion', ensureOption(options, 'tech_version', techVersionDefault));
+    const product = ensureOption(options, 'product', productDefault);
+
     let sdkVersions = {
-      sdkCode: ensureOption(options, 'sdkCode', sdkCode),
-      sdkSemver: ensureOption(options, 'sdkSemver', sdkSemver),
-      techVersion: ensureOption(options, 'techVersion', techVersion),
-      product: ensureOption(options, 'product', product),
+      sdkCode: sdkCode,
+      sdkSemver: sdkSemver,
+      techVersion: techVersion,
+      product: product,
       urlAnalytics
     };
 

--- a/test/testUtils/createTestConfig.js
+++ b/test/testUtils/createTestConfig.js
@@ -1,12 +1,13 @@
 const defaultConfigOptions = {
-  urlAnalytics: false
+  urlAnalytics: false,
+  analytics: false
 };
 
 /**
  * @description Creates a default config for testing, add properties to defaultConfigOptions to
  *              make them global across all tests
  * @param {{}} [confOptions] Cloudinary's config options
- * @return {{} & {urlAnalytics: true} & any}
+ * @return {{} & {analytics: true} & any}
  */
 function createTestConfig(confOptions = {}) {
   return Object.assign({}, defaultConfigOptions, confOptions);

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -4,7 +4,7 @@ const cloudinary = require('../../../cloudinary');
 const assert = require("assert");
 const TEST_CLOUD_NAME = require('../../testUtils/testConstants').TEST_CLOUD_NAME;
 
-describe.only('SDK url analytics', () => {
+describe('SDK url analytics', () => {
   let processVersions = {};
 
   before(() => {

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -85,9 +85,9 @@ describe.only('SDK url analytics', () => {
     const imgStr = cloudinary.image("hello", {
       format: "png",
       analytics: true,
-      sdkCode: "X",
-      sdkSemver: "7.3.0",
-      techVersion: "3.4.7",
+      sdk_code: "X",
+      sdk_semver: "7.3.0",
+      tech_version: "3.4.7",
       product: 'B'
     });
 


### PR DESCRIPTION
### Brief Summary of Changes
Previously added `urlAnalytics` is not consistent with the naming convention we had so far in the repo. I added `analytics` side by side. If someone used `urlAnalytics` earlier and is also using `analytics`, the older takes precedence.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
