### PR TITLE
fix: use 0.0.0 as fallback when package.json unavailable

### DIFF
--- a/lib/utils/analytics/getSDKVersions.js
+++ b/lib/utils/analytics/getSDKVersions.js
@@ -2,6 +2,19 @@ const fs = require('fs');
 const path = require('path');
 const sdkCode = 'M'; // Constant per SDK
 
+function readSdkSemver() {
+  const pkgJsonPath = path.join(__dirname, '../../../package.json');
+  try {
+    const pkgJSONFile = fs.readFileSync(pkgJsonPath, 'utf-8');
+    return JSON.parse(pkgJSONFile).version
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return '0.0.0'
+    }
+    return 'n/a';
+  }
+}
+
 /**
  * @description Gets the relevant versions of the SDK(package version, node version and sdkCode)
  * @param {'default' | 'x.y.z' | 'x.y' | string} useSDKVersion Default uses package.json version
@@ -9,10 +22,8 @@ const sdkCode = 'M'; // Constant per SDK
  * @return {{sdkSemver:string, techVersion:string, sdkCode:string}} A map of relevant versions and codes
  */
 function getSDKVersions(useSDKVersion = 'default', useNodeVersion = 'default') {
-  const pkgJSONFile = fs.readFileSync(path.join(__dirname, '../../../package.json'), 'utf-8');
-
   // allow to pass a custom SDKVersion
-  const sdkSemver = useSDKVersion === 'default' ? JSON.parse(pkgJSONFile).version : useSDKVersion;
+  const sdkSemver = useSDKVersion === 'default' ? readSdkSemver() : useSDKVersion;
 
   // allow to pass a custom techVersion (Node version)
   const techVersion = useNodeVersion === 'default' ? process.versions.node : useNodeVersion;

--- a/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
+++ b/test/unit/sdkAnalytics/imageTagWithAnalytics.spec.js
@@ -1,7 +1,11 @@
 const path = require('path');
 const mock = require('mock-fs');
-const cloudinary = require('../../../cloudinary');
 const assert = require("assert");
+const sinon = require("sinon");
+const fs = require('fs');
+
+const cloudinary = require('../../../cloudinary');
+
 const TEST_CLOUD_NAME = require('../../testUtils/testConstants').TEST_CLOUD_NAME;
 
 describe('SDK url analytics', () => {
@@ -12,132 +16,165 @@ describe('SDK url analytics', () => {
 
     processVersions = process.versions;
     delete process.versions;
-
-    const file = path.join(__dirname, '../../../package.json');
-
-    mock({
-      [file]: '{"version":"1.24.0"}'
-    });
   });
 
   after(() => {
-    mock.restore();
     process.versions = processVersions;
   });
 
-  it('can be turned off via options', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
+  describe('when package json is available', () => {
+    before(() => {
+      const file = path.join(__dirname, '../../../package.json');
 
-    const imgStr = cloudinary.image("hello", {
-      format: "png",
-      analytics: false
+      mock({
+        [file]: '{"version":"1.24.0"}'
+      });
     });
 
-    assert.ok(!imgStr.includes('MAlhAM0'))
-  });
-
-  it('defaults to true even if analytics is not passed as an option', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
-
-    const imgStr = cloudinary.image("hello", {
-      format: "png"
+    after(() => {
+      mock.restore();
     });
 
-    assert.ok(imgStr.includes('MAlhAM0'))
-  });
-
-  it('reads from process.versions and package.json (Mocked)', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
-
-    const imgStr = cloudinary.image("hello", {
-      format: "png",
-      analytics: true
-    });
-
-    assert.ok(imgStr.includes('?_a=BAMAlhAM0'));
-  });
-
-  it('reads from process.versions and package.json (Mocked) - Responsive', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
-
-    const imgStr = cloudinary.image("hello", {
-      format: "png",
-      responsive: true,
-      analytics: true
-    });
-
-    assert.ok(imgStr.includes('?_a=BAMAlhAMA'));
-  });
-
-  it('reads from tracked analytics configuration', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
-
-    const imgStr = cloudinary.image("hello", {
-      format: "png",
-      analytics: true,
-      sdk_code: "X",
-      sdk_semver: "7.3.0",
-      tech_version: "3.4.7",
-      product: 'B'
-    });
-
-    assert.ok(imgStr.includes('?_a=BBXAEzGT0'));
-  });
-
-  it('should still accept analytics param passed as camel case', () => {
-    process.versions = {
-      node: '12.0.0'
-    };
-
-    const imgStr = cloudinary.image("hello", {
-      format: "png",
-      urlAnalytics: true,
-      sdkCode: "X",
-      sdkSemver: "7.3.0",
-      techVersion: "3.4.7",
-      product: 'B'
-    });
-
-    assert.ok(imgStr.includes('?_a=BBXAEzGT0'));
-  });
-
-  describe('with two different casings', () => {
-    it('should treat camel case analytics param as more important than snake case', () => {
+    it('can be turned off via options', () => {
       process.versions = {
         node: '12.0.0'
       };
 
-      const imgStr1 = cloudinary.image("hello", {
+      const imgStr = cloudinary.image("hello", {
         format: "png",
-        urlAnalytics: true,
-        analytics: false,
-        sdkCode: "X",
-        sdkSemver: "7.3.0",
-        techVersion: "3.4.7",
-        product: 'B'
+        analytics: false
       });
-      assert.ok(imgStr1.includes('?_a=BBXAEzGT0'));
 
-      const imgStr2 = cloudinary.image("hello", {
+      assert.ok(!imgStr.includes('MAlhAM0'))
+    });
+
+    it('defaults to true even if analytics is not passed as an option', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const imgStr = cloudinary.image("hello", {
+        format: "png"
+      });
+
+      assert.ok(imgStr.includes('MAlhAM0'))
+    });
+
+    it('reads from process.versions and package.json (Mocked)', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const imgStr = cloudinary.image("hello", {
+        format: "png",
+        analytics: true
+      });
+
+      assert.ok(imgStr.includes('?_a=BAMAlhAM0'));
+    });
+
+    it('reads from process.versions and package.json (Mocked) - Responsive', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const imgStr = cloudinary.image("hello", {
+        format: "png",
+        responsive: true,
+        analytics: true
+      });
+
+      assert.ok(imgStr.includes('?_a=BAMAlhAMA'));
+    });
+
+    it('reads from tracked analytics configuration', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const imgStr = cloudinary.image("hello", {
         format: "png",
         analytics: true,
+        sdk_code: "X",
+        sdk_semver: "7.3.0",
+        tech_version: "3.4.7",
+        product: 'B'
+      });
+
+      assert.ok(imgStr.includes('?_a=BBXAEzGT0'));
+    });
+
+    it('should still accept analytics param passed as camel case', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const imgStr = cloudinary.image("hello", {
+        format: "png",
+        urlAnalytics: true,
         sdkCode: "X",
         sdkSemver: "7.3.0",
         techVersion: "3.4.7",
-        tech_version: "1.2.3",
         product: 'B'
       });
-      assert.ok(imgStr2.includes('?_a=BBXAEzGT0'));
+
+      assert.ok(imgStr.includes('?_a=BBXAEzGT0'));
+    });
+
+    describe('with two different casings', () => {
+      it('should treat camel case analytics param as more important than snake case', () => {
+        process.versions = {
+          node: '12.0.0'
+        };
+
+        const imgStr1 = cloudinary.image("hello", {
+          format: "png",
+          urlAnalytics: true,
+          analytics: false,
+          sdkCode: "X",
+          sdkSemver: "7.3.0",
+          techVersion: "3.4.7",
+          product: 'B'
+        });
+        assert.ok(imgStr1.includes('?_a=BBXAEzGT0'));
+
+        const imgStr2 = cloudinary.image("hello", {
+          format: "png",
+          analytics: true,
+          sdkCode: "X",
+          sdkSemver: "7.3.0",
+          techVersion: "3.4.7",
+          tech_version: "1.2.3",
+          product: 'B'
+        });
+        assert.ok(imgStr2.includes('?_a=BBXAEzGT0'));
+      });
+    });
+  });
+
+  describe('when package.json is unavailable', () => {
+    before(() => {
+      const enoent = new Error('ENOENT');
+      enoent.code = 'ENOENT';
+      sinon.stub(fs, 'readFileSync').throws(enoent);
+    });
+
+    after(() => {
+      sinon.restore();
+    });
+
+    it('uses 0.0.0 as fallback sdk semver', () => {
+      process.versions = {
+        node: '12.0.0'
+      };
+
+      const urlWithToken = cloudinary.url("hello", {
+        format: "png",
+        analytics: true
+      });
+
+      const [url, analyticsToken] = urlWithToken.split('?_a=');
+      assert.strictEqual(analyticsToken, 'BAMAAAAM0');
     });
   });
 });


### PR DESCRIPTION
### Brief Summary of Changes
Under certain circumstances when package.json is unavailable, the sdk could not read the version of itself (which is necessary to calculate analytics token appended to the url). It caused an error to be thrown "Must provide sdkSemver". This PR fixes it and allows sdk to fail gracefully - `0.0.0` is used as a fallback if package.json is unavailable.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
