### PR TITLE
Add missing type definition

### DIFF
--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -916,7 +916,7 @@ cloudinary.v2.utils.download_folder(
     'my-folder',
     {
         resource_type: 'image',
-        prefix: 'photos/'
+        prefixes: 'photos/'
     }
 );
 

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -911,6 +911,16 @@ cloudinary.v2.utils.download_zip_url(
     }
 );
 
+// $ExpectType string
+cloudinary.v2.utils.download_folder(
+    'my-folder',
+    {
+        resource_type: 'image',
+        prefix: 'photos/'
+    }
+);
+
+
 // $ExpectType { [key: string]: any; signature: string; api_key: string; }
 cloudinary.v2.utils.sign_request(
     {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -924,6 +924,8 @@ declare module 'cloudinary' {
 
             function download_zip_url(options?: ArchiveApiOptions | ConfigAndUrlOptions): string;
 
+            function download_folder(folder_path: string, options?: ArchiveApiOptions | ConfigAndUrlOptions): string;
+
             function download_backedup_asset(asset_id?: string, version_id?: string, options?: ArchiveApiOptions | ConfigAndUrlOptions): string
 
             function generate_auth_token(options?: AuthTokenApiOptions): string;


### PR DESCRIPTION
### Brief Summary of Changes
Typescript type definitions doesn't include all the methods, notably download_folder which I was trying to use instead of download_zip_url because this has a limit of 1000 asset.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #675)

#### Are Tests Included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
No new code added, this just adds an existing method in js to typescript type definition.