### PR TITLE
feat: exposing config endpoint from admin api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -692,3 +692,8 @@ exports.update_metadata_rule = function update_metadata_rule(field_external_id, 
 exports.delete_metadata_rule = function delete_metadata_rule(field_external_id, callback, options = {}) {
   return call_api('delete', ['metadata_rules', field_external_id], {}, callback, options);
 };
+
+exports.config = function config(callback, options = {}) {
+  const params = pickOnlyExistingValues(options, 'settings');
+  return call_api('get', ['config'], params, callback, options);
+}

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -74,5 +74,6 @@ v1_adapters(exports, api, {
   add_related_assets: 2,
   add_related_assets_by_asset_id: 2,
   delete_related_assets: 2,
-  delete_related_assets_by_asset_id: 2
+  delete_related_assets_by_asset_id: 2,
+  config: 0
 });

--- a/test/integration/api/admin/config_spec.js
+++ b/test/integration/api/admin/config_spec.js
@@ -1,0 +1,43 @@
+const sinon = require('sinon');
+
+const cloudinary = require('../../../../lib/cloudinary');
+const api_http = require("https");
+const ClientRequest = require('_http_client').ClientRequest;
+
+describe('Admin API - Config', () => {
+  const mocked = {};
+
+  beforeEach(function () {
+    mocked.xhr = sinon.useFakeXMLHttpRequest();
+    mocked.write = sinon.spy(ClientRequest.prototype, 'write');
+    mocked.request = sinon.spy(api_http, 'request');
+  });
+
+  afterEach(function () {
+    mocked.request.restore();
+    mocked.write.restore();
+    mocked.xhr.restore();
+  });
+
+  describe('config', () => {
+    it('should send a request to config endpoint', () => {
+      cloudinary.v2.api.config();
+
+      sinon.assert.calledWith(mocked.request, sinon.match({
+        pathname: sinon.match('config'),
+        method: sinon.match('GET'),
+        query: sinon.match('')
+      }));
+    });
+
+    it('should send a request to config endpoint with optional parameters', () => {
+      cloudinary.v2.api.config({ settings: true });
+
+      sinon.assert.calledWith(mocked.request, sinon.match({
+        pathname: sinon.match('config'),
+        method: sinon.match('GET'),
+        query: sinon.match('settings=true')
+      }));
+    });
+  });
+});

--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -1206,6 +1206,12 @@ cloudinary.v2.api.delete_related_assets_by_asset_id('asset-id', 'public-id-to-un
 // $ExpectType Promise<DeleteAssetRelation>
 cloudinary.v2.api.delete_related_assets_by_asset_id('asset-id', ['public-id-to-unrelate-1', 'public-id-to-unrelate-2']);
 
+// $ExpectType Promise<ConfigResponse>
+cloudinary.v2.api.config();
+
+// $ExpectType Promise<ConfigResponse>
+cloudinary.v2.api.config({ settings: true });
+
 // $ExpectType Promise<any>
 cloudinary.v2.uploader.create_slideshow({
     manifest_json: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -949,7 +949,7 @@ declare module 'cloudinary' {
         /****************************** Admin API V2 Methods *************************************/
 
         namespace api {
-            function config(options: AdminApiOptions | { settings: boolean }, callback?: ResponseCallback): Promise<ConfigResponse>
+            function config(options?: AdminApiOptions | { settings: boolean }, callback?: ResponseCallback): Promise<ConfigResponse>
 
             function create_streaming_profile(name: string, options: AdminApiOptions | {
                 display_name?: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -870,6 +870,14 @@ declare module 'cloudinary' {
         }
     }
 
+    export interface ConfigResponse {
+        cloud_name: string
+        created_at: string
+        settings?: {
+            folder_mode: 'fixed' | 'dynamic'
+        }
+    }
+
     export namespace v2 {
 
         /****************************** Global Utils *************************************/
@@ -941,6 +949,8 @@ declare module 'cloudinary' {
         /****************************** Admin API V2 Methods *************************************/
 
         namespace api {
+            function config(options: AdminApiOptions | { settings: boolean }, callback?: ResponseCallback): Promise<ConfigResponse>
+
             function create_streaming_profile(name: string, options: AdminApiOptions | {
                 display_name?: string,
                 representations: TransformationOptions


### PR DESCRIPTION
### Brief Summary of Changes
Exposing config endpoint via `cloudinary.v2.api.config()`

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
