### PR TITLE
fix: added missing stream method to ts spec

### DIFF
--- a/types/cloudinary_ts_spec.ts
+++ b/types/cloudinary_ts_spec.ts
@@ -986,6 +986,11 @@ cloudinary.v2.uploader.upload_stream(
         console.log(result);
     });
 
+// $ExpectType UploadStream
+cloudinary.v2.uploader.upload_chunked_stream({template: "https://www.example.com/images/"});
+
+// $ExpectType UploadStream
+cloudinary.v2.uploader.upload_large_stream({template: "https://www.example.com/images/"});
 
 // $ExpectType Promise<any>
 cloudinary.v2.provisioning.account.sub_accounts(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1397,6 +1397,8 @@ declare module 'cloudinary' {
 
             function upload_chunked_stream(options?: UploadApiOptions, callback?: UploadResponseCallback): UploadStream;
 
+            function upload_large_stream(options?: UploadApiOptions, callback?: UploadResponseCallback): UploadStream;
+
             function upload_large(path: string, options?: UploadApiOptions, callback?: UploadResponseCallback): Promise<UploadApiResponse>;
 
             function upload_large(path: string, callback?: UploadResponseCallback): Promise<UploadApiResponse>;


### PR DESCRIPTION
### Brief Summary of Changes
Added missing method to ts specification: `upload_large_stream`.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
