### PR TITLE
feat: Add support for DELETE /resources/backup/:asset_id

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -178,6 +178,18 @@ exports.delete_all_resources = function delete_all_resources(callback, options =
   }), callback, options);
 };
 
+exports.delete_backed_up_assets = (assetId, versionIds, callback, options = {}) => {
+  const params = deleteBackupParams(versionIds);
+
+  return call_api('delete', ['resources', 'backup', assetId], params, callback, options);
+}
+
+const deleteBackupParams = (versionIds = []) => {
+  return {
+    "version_ids[]": Array.isArray(versionIds) ? versionIds : [versionIds]
+  };
+};
+
 const createRelationParams = (publicIds = []) => {
   return {
     assets_to_relate: Array.isArray(publicIds) ? publicIds : [publicIds]

--- a/lib/v2/api.js
+++ b/lib/v2/api.js
@@ -75,5 +75,6 @@ v1_adapters(exports, api, {
   add_related_assets_by_asset_id: 2,
   delete_related_assets: 2,
   delete_related_assets_by_asset_id: 2,
+  delete_backed_up_assets: 2,
   config: 0
 });


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
Adds support for deleting the backed-up versions of a resource, as per https://cloudinary.com/documentation/admin_api#delete_backed_up_versions_of_a_resource

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [x] Yes
- [ ] No