### PR TITLE
fix: defaults for related asset methods and proper content_type

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -204,21 +204,29 @@ const deleteRelationParams = (publicIds = []) => {
 
 exports.add_related_assets = (publicId, assetsToRelate, callback, options = {}) => {
   const params = createRelationParams(assetsToRelate);
-  return call_api('post', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
+  const resourceType = options.resource_type || 'image';
+  const type = options.type || 'upload';
+  options.content_type = 'json';
+  return call_api('post', ['resources', 'related_assets', resourceType, type, publicId], params, callback, options);
 };
 
 exports.add_related_assets_by_asset_id = (assetId, assetsToRelate, callback, options = {}) => {
   const params = createRelationParams(assetsToRelate);
+  options.content_type = 'json';
   return call_api('post', ['resources', 'related_assets', assetId], params, callback, options);
 };
 
 exports.delete_related_assets = (publicId, assetsToUnrelate, callback, options = {}) => {
   const params = deleteRelationParams(assetsToUnrelate);
-  return call_api('delete', ['resources', 'related_assets', options.resource_type, options.type, publicId], params, callback, options);
+  const resourceType = options.resource_type || 'image';
+  const type = options.type || 'upload';
+  options.content_type = 'json';
+  return call_api('delete', ['resources', 'related_assets', resourceType, type, publicId], params, callback, options);
 };
 
 exports.delete_related_assets_by_asset_id = (assetId, assetsToUnrelate, callback, options = {}) => {
   const params = deleteRelationParams(assetsToUnrelate);
+  options.content_type = 'json';
   return call_api('delete', ['resources', 'related_assets', assetId], params, callback, options);
 };
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-import": "^2.20.2",
     "expect.js": "0.3.x",
     "glob": "^7.1.6",
-    "jsdoc": "^3.6.11",
+    "jsdoc": "^4.0.4",
     "jsdom": "^9.12.0",
     "jsdom-global": "2.1.1",
     "mocha": "^6.2.3",

--- a/test/integration/api/admin/related_assets_spec.js
+++ b/test/integration/api/admin/related_assets_spec.js
@@ -16,31 +16,25 @@ describe('Asset relations API', () => {
     describe('using public id', () => {
       it('should allow passing a single public id to create a relation', () => {
         return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets(testPublicId, singleRelatedPublicId, {
-            resource_type: 'image',
-            type: 'upload'
-          });
+          cloudinary.v2.api.add_related_assets(testPublicId, singleRelatedPublicId);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_relate\":[\"related-public-id\"]}"]);
         });
       });
 
       it('should allow passing multiple public ids to create a relation', () => {
         return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets(testPublicId, multipleRelatedPublicId, {
-            resource_type: 'image',
-            type: 'upload'
-          });
+          cloudinary.v2.api.add_related_assets(testPublicId, multipleRelatedPublicId);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/${testPublicId}`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_relate\":[\"related-public-id-1\",\"related-public-id-2\"]}"]);
         });
       });
     });
@@ -54,7 +48,7 @@ describe('Asset relations API', () => {
           strictEqual(calledWithUrl.method, 'POST');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_relate\":[\"related-public-id\"]}"]);
         });
       });
 
@@ -66,7 +60,7 @@ describe('Asset relations API', () => {
           strictEqual(calledWithUrl.method, 'POST');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_relate=related-public-id-1&assets_to_relate=related-public-id-2']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_relate\":[\"related-public-id-1\",\"related-public-id-2\"]}"]);
         });
       });
     });
@@ -76,31 +70,25 @@ describe('Asset relations API', () => {
     describe('using public id', () => {
       it('should allow passing a single public id to delete a relation', () => {
         return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets(testPublicId, singleRelatedPublicId, {
-            resource_type: 'image',
-            type: 'upload'
-          });
+          cloudinary.v2.api.delete_related_assets(testPublicId, singleRelatedPublicId);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_unrelate\":[\"related-public-id\"]}"]);
         });
       });
 
       it('should allow passing multiple public ids to delete a relation', () => {
         return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets(testPublicId, multipleRelatedPublicId, {
-            resource_type: 'image',
-            type: 'upload'
-          });
+          cloudinary.v2.api.delete_related_assets(testPublicId, multipleRelatedPublicId);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/image/upload/test-public-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_unrelate\":[\"related-public-id-1\",\"related-public-id-2\"]}"]);
         });
       });
     });
@@ -114,7 +102,7 @@ describe('Asset relations API', () => {
           strictEqual(calledWithUrl.method, 'DELETE');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_unrelate\":[\"related-public-id\"]}"]);
         });
       });
 
@@ -126,7 +114,7 @@ describe('Asset relations API', () => {
           strictEqual(calledWithUrl.method, 'DELETE');
           strictEqual(calledWithUrl.path, `/v1_1/${TEST_CLOUD_NAME}/resources/related_assets/test-asset-id`);
           const callApiArguments = writeSpy.firstCall.args;
-          deepStrictEqual(callApiArguments, ['assets_to_unrelate=related-public-id-1&assets_to_unrelate=related-public-id-2']);
+          deepStrictEqual(callApiArguments, ["{\"assets_to_unrelate\":[\"related-public-id-1\",\"related-public-id-2\"]}"]);
         });
       });
     });


### PR DESCRIPTION
### Brief Summary of Changes
- added correct defaults for related asset methods.
- passing `json` as content_type in those methods

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No