### PR TITLE
Support target_asset_folder for generate archive

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1284,6 +1284,8 @@ function api_download_url(action, params, options) {
  * @param {string} [options.target_format="zip"]
  * @param {string} [options.target_public_id]  public ID of the generated raw resource.
  *   Relevant only for the create mode. If not specified, random public ID is generated.
+ * @param {string} [options.target_asset_folder] The folder where the generated file is placed within the Cloudinary repository.
+ *   Not supported for product environments using the legacy fixed folder mode
  * @param {boolean} [options.flatten_folders=false] If true, flatten public IDs with folders to be in the root
  *   of the archive. Add numeric counter to the file name in case of a name conflict.
  * @param {boolean} [options.flatten_transformations=false] If true, and multiple transformations are given,
@@ -1506,6 +1508,7 @@ function archive_params(options = {}) {
     tags: options.tags && toArray(options.tags),
     target_format: options.target_format,
     target_public_id: options.target_public_id,
+    target_asset_folder: options.target_asset_folder,
     target_tags: options.target_tags && toArray(options.target_tags),
     timestamp: options.timestamp || exports.timestamp(),
     transformations: utils.build_eager(options.transformations),

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -37,7 +37,7 @@ const PUBLIC_ID2 = ARCHIVE_TAG + "_2";
 const PUBLIC_ID_RAW = ARCHIVE_TAG + "_3";
 const FULLY_QUALIFIED_IMAGE = "image/upload/sample";
 const FULLY_QUALIFIED_VIDEO = "video/upload/dog";
-
+const TARGET_ASSET_FOLDER = 'test-folder';
 
 describe("archive", function () {
   this.timeout(TIMEOUT.LONG);
@@ -155,12 +155,14 @@ describe("archive", function () {
             tags: TEST_TAG,
             public_ids: [PUBLIC_ID_RAW, "non-existing-resource"],
             resource_type: "raw",
-            allow_missing: true
+            allow_missing: true,
+            target_asset_folder: TARGET_ASSET_FOLDER
           });
           sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("tags[]", TEST_TAG)));
           sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("public_ids[]", PUBLIC_ID_RAW)));
           sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("public_ids[]", "non-existing-resource")));
           sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("allow_missing", 1)));
+          sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("target_asset_folder", TARGET_ASSET_FOLDER)));
           sinon.assert.calledWith(writeSpy, sinon.match(helper.uploadParamMatcher("target_format", "zip")));
         });
       });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -428,6 +428,7 @@ declare module 'cloudinary' {
         tags?: string | string[];
         target_format?: TargetArchiveFormat;
         target_public_id?: string;
+        target_asset_folder?: string;
         target_tags?: string[];
         timestamp?: number;
         transformations?: TransformationOptions;


### PR DESCRIPTION
### Brief Summary of Changes
`target_asset_folder` (relevant for Dynamic Folder-based product environments) was not supported as part of `generate_archive` params.

#### What Does This PR Address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are Tests Included?
- [X] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
