### PR TITLE
small fix for prevention of process in uploader.js

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -92,6 +92,7 @@ class Chunkable extends Writable {
   _write(data, encoding, done) {
     if (!this.active) {
       done();
+      return; // prevent further processing when the stream is inactive
     }
     if (this.buffer.length + data.length <= this.chunk_size) {
       this.buffer = Buffer.concat([this.buffer, data], this.buffer.length + data.length);


### PR DESCRIPTION
## Recent small fix
- Fix: prevent further processing when chunk stream is inactive.
- File changed: `lib/uploader.js`
- Change: added early return in Chunkable._write:
  ```js
  if (!this.active) {
    done();
    return; // prevent further processing when the stream is inactive
  }
  ```
- Why: avoids double-callbacks or processing remaining data when the stream has been marked inactive.
- Risk: minimal — only affects the inactive path.

