### PR TITLE
refactor: use native promises and drop q

### DIFF
--- a/lib/api_client/execute_request.js
+++ b/lib/api_client/execute_request.js
@@ -2,7 +2,6 @@
 const config = require("../config");
 const https = /^http:/.test(config().upload_prefix) ? require('http') : require('https');
 const querystring = require("querystring");
-const Q = require('q');
 const url = require('url');
 const utils = require("../utils");
 const ensureOption = require('../utils/ensureOption').defaults(config());
@@ -13,7 +12,7 @@ const agent = config.api_proxy ? new https.Agent(config.api_proxy) : null;
 
 function execute_request(method, params, auth, api_url, callback, options = {}) {
   method = method.toUpperCase();
-  const deferred = Q.defer();
+  const deferred = utils.deferredPromise();
 
   let query_params, handle_response; // declare to user later
   let key = auth.key;

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const { extname, basename } = require('path');
-const Q = require('q');
 const Writable = require("stream").Writable;
 const urlLib = require('url');
 
@@ -466,7 +465,7 @@ function call_api(action, callback, options, get_params) {
 
   const USE_PROMISES = !options.disable_promises;
 
-  let deferred = Q.defer();
+  const deferred = utils.deferredPromise();
   if (options == null) {
     options = {};
   }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1652,6 +1652,22 @@ function jsonArrayParam(data, modifier) {
  */
 exports.NOP = function () {
 };
+
+function deferredPromise() {
+  let resolve, reject
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return {
+    resolve,
+    reject,
+    promise
+  };
+}
+
+exports.deferredPromise = deferredPromise;
+
 exports.generate_auth_token = generate_auth_token;
 exports.getUserAgent = getUserAgent;
 exports.build_upload_params = build_upload_params;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "main": "cloudinary.js",
   "dependencies": {
-    "lodash": "^4.17.21",
-    "q": "^1.5.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",

--- a/test/integration/api/admin/config_spec.js
+++ b/test/integration/api/admin/config_spec.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 
 const cloudinary = require('../../../../lib/cloudinary');
 const api_http = require("https");
+const { NOP } = require('../../../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('Admin API - Config', () => {
@@ -20,8 +21,8 @@ describe('Admin API - Config', () => {
   });
 
   describe('config', () => {
-    it('should send a request to config endpoint', () => {
-      cloudinary.v2.api.config();
+    it('should send a request to config endpoint', async () => {
+      await cloudinary.v2.api.config().catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('config'),
@@ -30,8 +31,8 @@ describe('Admin API - Config', () => {
       }));
     });
 
-    it('should send a request to config endpoint with optional parameters', () => {
-      cloudinary.v2.api.config({ settings: true });
+    it('should send a request to config endpoint with optional parameters', async () => {
+      await cloudinary.v2.api.config({ settings: true }).catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('config'),

--- a/test/integration/api/admin/folders_api_spec.js
+++ b/test/integration/api/admin/folders_api_spec.js
@@ -5,6 +5,7 @@ const cloudinary = require('../../../../lib/cloudinary');
 const createTestConfig = require('../../../testUtils/createTestConfig');
 const helper = require('../../../spechelper');
 const api_http = require("https");
+const { NOP } = require('../../../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('Admin API - Folders', () => {
@@ -23,8 +24,8 @@ describe('Admin API - Folders', () => {
   });
 
   describe('rename_folder', () => {
-    it('should send a request to update folder endpoint with correct parameters', () => {
-      cloudinary.v2.api.rename_folder('old/path', 'new/path');
+    it('should send a request to update folder endpoint with correct parameters', async () => {
+      await cloudinary.v2.api.rename_folder('old/path', 'new/path').catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('old%2Fpath'),

--- a/test/integration/api/admin/related_assets_spec.js
+++ b/test/integration/api/admin/related_assets_spec.js
@@ -5,6 +5,7 @@ const {
   deepStrictEqual
 } = require('assert');
 const {TEST_CLOUD_NAME} = require('../../../testUtils/testConstants');
+const { NOP } = require('../../../../lib/utils');
 
 describe('Asset relations API', () => {
   const testPublicId = 'test-public-id';
@@ -15,8 +16,8 @@ describe('Asset relations API', () => {
   describe('when creating new relation', () => {
     describe('using public id', () => {
       it('should allow passing a single public id to create a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets(testPublicId, singleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.add_related_assets(testPublicId, singleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
@@ -27,8 +28,8 @@ describe('Asset relations API', () => {
       });
 
       it('should allow passing multiple public ids to create a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets(testPublicId, multipleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.add_related_assets(testPublicId, multipleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
@@ -41,8 +42,8 @@ describe('Asset relations API', () => {
 
     describe('using asset id', () => {
       it('should allow passing a single public id to create a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, singleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, singleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
@@ -53,8 +54,8 @@ describe('Asset relations API', () => {
       });
 
       it('should allow passing multiple public ids to create a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.add_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'POST');
@@ -69,8 +70,8 @@ describe('Asset relations API', () => {
   describe('when deleting existing relation', () => {
     describe('using public id', () => {
       it('should allow passing a single public id to delete a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets(testPublicId, singleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.delete_related_assets(testPublicId, singleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
@@ -81,8 +82,8 @@ describe('Asset relations API', () => {
       });
 
       it('should allow passing multiple public ids to delete a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets(testPublicId, multipleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.delete_related_assets(testPublicId, multipleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
@@ -95,8 +96,8 @@ describe('Asset relations API', () => {
 
     describe('and using asset id', () => {
       it('should allow passing a single public id to delete a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, singleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, singleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');
@@ -107,8 +108,8 @@ describe('Asset relations API', () => {
       });
 
       it('should allow passing multiple public ids to delete a relation', () => {
-        return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-          cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId);
+        return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+          await cloudinary.v2.api.delete_related_assets_by_asset_id(testAssetId, multipleRelatedPublicId).catch(NOP);
 
           const [calledWithUrl] = requestSpy.firstCall.args;
           strictEqual(calledWithUrl.method, 'DELETE');

--- a/test/integration/api/analysis/analyze_spec.js
+++ b/test/integration/api/analysis/analyze_spec.js
@@ -5,6 +5,7 @@ const api_http = require('https');
 
 const cloudinary = require('../../../../cloudinary');
 const helper = require('../../../spechelper');
+const { NOP } = require('../../../../lib/utils');
 
 describe('Analyze API', () => {
   describe('uri analysis', () => {
@@ -25,8 +26,8 @@ describe('Analyze API', () => {
       mocked.xhr.restore();
     });
 
-    it('should call analyze endpoint with non-custom analysis_type', () => {
-      cloudinary.analysis.analyze_uri('https://example.com', 'captioning');
+    it('should call analyze endpoint with non-custom analysis_type', async () => {
+      await cloudinary.analysis.analyze_uri('https://example.com', 'captioning').catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),
@@ -36,11 +37,11 @@ describe('Analyze API', () => {
       sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('analysis_type', 'captioning')));
     });
 
-    it('should call analyze endpoint with custom analysis_type', () => {
-      cloudinary.analysis.analyze_uri('https://example.com', 'custom', {
+    it('should call analyze endpoint with custom analysis_type', async () => {
+      await cloudinary.analysis.analyze_uri('https://example.com', 'custom', {
         model_name: 'my_model',
         model_version: 1
-      });
+      }).catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match(new RegExp(`/v2/${config.cloud_name}/analysis/analyze/uri`)),

--- a/test/integration/api/authorization/oAuth_authorization_spec.js
+++ b/test/integration/api/authorization/oAuth_authorization_spec.js
@@ -3,14 +3,15 @@ const cloudinary = require("../../../../cloudinary");
 const helper = require("../../../spechelper");
 const describe = require('../../../testUtils/suite');
 const testConstants = require('../../../testUtils/testConstants');
+const { NOP } = require('../../../../lib/utils');
 const { PUBLIC_IDS } = testConstants;
 const { PUBLIC_ID } = PUBLIC_IDS;
 
 describe("oauth_token", function(){
   it("should send the oauth_token option to the server (admin_api)", function() {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.api.resource(PUBLIC_ID, { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
-      return sinon.assert.calledWith(requestSpy,
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.api.resource(PUBLIC_ID, { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' }).catch(NOP);
+      sinon.assert.calledWith(requestSpy,
         sinon.match.has("headers",
           sinon.match.has("Authorization", "Bearer MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
         ));
@@ -18,14 +19,14 @@ describe("oauth_token", function(){
   });
 
   it("should send the oauth_token config to the server (admin_api)", function() {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
       cloudinary.config({
         api_key: undefined,
         api_secret: undefined,
         oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4'
       });
-      cloudinary.v2.api.resource(PUBLIC_ID);
-      return sinon.assert.calledWith(requestSpy,
+      await cloudinary.v2.api.resource(PUBLIC_ID).catch(NOP);
+      sinon.assert.calledWith(requestSpy,
         sinon.match.has("headers",
           sinon.match.has("Authorization", "Bearer MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
         ));
@@ -38,9 +39,9 @@ describe("oauth_token", function(){
       api_secret: "1234",
       oauth_token: undefined
     });
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.api.resource(PUBLIC_ID);
-      return sinon.assert.calledWith(requestSpy, sinon.match({ auth: "1234:1234" }));
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.api.resource(PUBLIC_ID).catch(NOP);
+      sinon.assert.calledWith(requestSpy, sinon.match({ auth: "1234:1234" }));
     });
   });
 
@@ -67,9 +68,9 @@ describe("oauth_token", function(){
   });
 
   it("should send the oauth_token option to the server (upload_api)", function() {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.uploader.upload(PUBLIC_ID, { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' });
-      return sinon.assert.calledWith(requestSpy,
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.uploader.upload(PUBLIC_ID, { oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4' }).catch(NOP);
+      sinon.assert.calledWith(requestSpy,
         sinon.match.has("headers",
           sinon.match.has("Authorization", "Bearer MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
         ));
@@ -77,14 +78,14 @@ describe("oauth_token", function(){
   });
 
   it("should send the oauth_token config to the server (upload_api)", function() {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
       cloudinary.config({
         api_key: undefined,
         api_secret: undefined,
         oauth_token: 'MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4'
       });
-      cloudinary.v2.uploader.upload(PUBLIC_ID);
-      return sinon.assert.calledWith(requestSpy,
+      await cloudinary.v2.uploader.upload(PUBLIC_ID).catch(NOP);
+      sinon.assert.calledWith(requestSpy,
         sinon.match.has("headers",
           sinon.match.has("Authorization", "Bearer MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI4")
         ));
@@ -97,9 +98,9 @@ describe("oauth_token", function(){
       api_secret: "1234",
       oauth_token: undefined
     });
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.uploader.upload(PUBLIC_ID)
-      return sinon.assert.calledWith(requestSpy, sinon.match({ auth: null }));
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.uploader.upload(PUBLIC_ID).catch(NOP);
+      sinon.assert.calledWith(requestSpy, sinon.match({ auth: null }));
     });
   });
 
@@ -120,9 +121,9 @@ describe("oauth_token", function(){
       api_secret: undefined,
       oauth_token: undefined
     });
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.uploader.unsigned_upload(PUBLIC_ID, 'preset')
-      return sinon.assert.calledWith(requestSpy, sinon.match({ auth: null }));
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.uploader.unsigned_upload(PUBLIC_ID, 'preset').catch(NOP);
+      sinon.assert.calledWith(requestSpy, sinon.match({ auth: null }));
     });
   });
 });

--- a/test/integration/api/search/visual_search_spec.js
+++ b/test/integration/api/search/visual_search_spec.js
@@ -5,11 +5,12 @@ const {
   deepStrictEqual
 } = require('assert');
 const {TEST_CLOUD_NAME} = require('../../../testUtils/testConstants');
+const { NOP } = require('../../../../lib/utils');
 
 describe('Visual search', () => {
   it('should pass the image_url parameter to the api call', () => {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.api.visual_search({image_url: 'test-image-url'});
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.api.visual_search({image_url: 'test-image-url'}).catch(NOP);
 
       const [calledWithUrl] = requestSpy.firstCall.args;
       strictEqual(calledWithUrl.method, 'GET');
@@ -18,8 +19,8 @@ describe('Visual search', () => {
   });
 
   it('should pass the image_url parameter to the api call', () => {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.api.visual_search({image_asset_id: 'image-asset-id'});
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.api.visual_search({image_asset_id: 'image-asset-id'}).catch(NOP);
 
       const [calledWithUrl] = requestSpy.firstCall.args;
       strictEqual(calledWithUrl.method, 'GET');
@@ -28,8 +29,8 @@ describe('Visual search', () => {
   });
 
   it('should pass the image_url parameter to the api call', () => {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      cloudinary.v2.api.visual_search({text: 'visual-search-input'});
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await cloudinary.v2.api.visual_search({text: 'visual-search-input'}).catch(NOP);
 
       const [calledWithUrl] = requestSpy.firstCall.args;
       strictEqual(calledWithUrl.method, 'GET');

--- a/test/integration/api/uploader/archivespec.js
+++ b/test/integration/api/uploader/archivespec.js
@@ -2,7 +2,6 @@ const https = require('https');
 const last = require('lodash/last');
 const sinon = require("sinon");
 const execSync = require('child_process').execSync;
-const Q = require('q');
 const fs = require('fs');
 const os = require('os');
 const describe = require('../../../testUtils/suite');
@@ -43,7 +42,7 @@ describe("archive", function () {
   this.timeout(TIMEOUT.LONG);
 
   before(function () {
-    return Q.all([
+    return Promise.all([
       uploader.upload(IMAGE_URL,
         {
           public_id: PUBLIC_ID1,
@@ -150,8 +149,8 @@ describe("archive", function () {
     describe('.create_zip', function () {
       this.timeout(TIMEOUT.LONG);
       it('should call create_archive with "zip" format and ignore missing resources', function () {
-        helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
-          uploader.create_zip({
+        return helper.provideMockObjects(async function (mockXHR, writeSpy, requestSpy) {
+          await uploader.create_zip({
             tags: TEST_TAG,
             public_ids: [PUBLIC_ID_RAW, "non-existing-resource"],
             resource_type: "raw",

--- a/test/integration/api/uploader/auto_chaptering_spec.js
+++ b/test/integration/api/uploader/auto_chaptering_spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const cloudinary = require('../../../../lib/cloudinary');
 const createTestConfig = require('../../../testUtils/createTestConfig');
 const helper = require('../../../spechelper');
+const { NOP } = require('../../../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('Uploader', () => {
@@ -21,15 +22,15 @@ describe('Uploader', () => {
   });
 
   describe('upload', () => {
-    it('should send a request with auto_chaptering set to true if requested', () => {
-      cloudinary.v2.uploader.upload('irrelevant', { auto_chaptering: true });
+    it('should send a request with auto_chaptering set to true if requested', async () => {
+      await cloudinary.v2.uploader.upload('irrelevant', { auto_chaptering: true }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_chaptering', '1')));
     });
   });
 
   describe('explicit', () => {
-    it('should send a request with auto_chaptering set to true if requested', () => {
-      cloudinary.v2.uploader.explicit('irrelevant', { auto_chaptering: true });
+    it('should send a request with auto_chaptering set to true if requested', async () => {
+      await cloudinary.v2.uploader.explicit('irrelevant', { auto_chaptering: true }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_chaptering', '1')));
     });
   });

--- a/test/integration/api/uploader/auto_transcription_spec.js
+++ b/test/integration/api/uploader/auto_transcription_spec.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const cloudinary = require('../../../../lib/cloudinary');
 const helper = require('../../../spechelper');
+const { NOP } = require('../../../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('Uploader', () => {
@@ -18,25 +19,25 @@ describe('Uploader', () => {
   });
 
   describe('upload', () => {
-    it('should send a request with auto_transcription set to true if requested', () => {
-      cloudinary.v2.uploader.upload('irrelevant', { auto_transcription: true });
+    it('should send a request with auto_transcription set to true if requested', async () => {
+      await cloudinary.v2.uploader.upload('irrelevant', { auto_transcription: true }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_transcription', '1')));
     });
 
-    it('should send a request with auto_transcription config if requested', () => {
-      cloudinary.v2.uploader.upload('irrelevant', { auto_transcription: { translate: ['pl'] } });
+    it('should send a request with auto_transcription config if requested', async () => {
+      await cloudinary.v2.uploader.upload('irrelevant', { auto_transcription: { translate: ['pl'] } }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_transcription', '{"translate":["pl"]}')));
     });
   });
 
   describe('explicit', () => {
-    it('should send a request with auto_transcription set to true if requested', () => {
-      cloudinary.v2.uploader.explicit('irrelevant', { auto_transcription: true });
+    it('should send a request with auto_transcription set to true if requested', async () => {
+      await cloudinary.v2.uploader.explicit('irrelevant', { auto_transcription: true }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_transcription', '1')));
     });
 
-    it('should send a request with auto_transcription config if requested', () => {
-      cloudinary.v2.uploader.explicit('irrelevant', { auto_transcription: { translate: ['pl'] } });
+    it('should send a request with auto_transcription config if requested', async () => {
+      await cloudinary.v2.uploader.explicit('irrelevant', { auto_transcription: { translate: ['pl'] } }).catch(NOP);
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('auto_transcription', '{"translate":["pl"]}')));
     });
   });

--- a/test/integration/api/uploader/custom_region_spec.js
+++ b/test/integration/api/uploader/custom_region_spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const cloudinary = require('../../../../lib/cloudinary');
 const createTestConfig = require('../../../testUtils/createTestConfig');
 const helper = require('../../../spechelper');
+const { NOP } = require('../../../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('Uploader', () => {
@@ -21,13 +22,13 @@ describe('Uploader', () => {
   });
 
   describe('upload', () => {
-    it('should send a request with encoded custom region gravity that represents a box', () => {
-      cloudinary.v2.uploader.upload('irrelevant', {
+    it('should send a request with encoded custom region gravity that represents a box', async () => {
+      await cloudinary.v2.uploader.upload('irrelevant', {
         regions: {
           'box_1': [[1, 2], [3, 4]],
           'box_2': [[5, 6], [7, 8]]
         }
-      });
+      }).catch(NOP);
 
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('regions', JSON.stringify({
         'box_1': [[1, 2], [3, 4]],
@@ -35,13 +36,13 @@ describe('Uploader', () => {
       }))));
     });
 
-    it('should send a request with encoded custom region gravity that represents a custom shape', () => {
-      cloudinary.v2.uploader.upload('irrelevant', {
+    it('should send a request with encoded custom region gravity that represents a custom shape', async () => {
+      await cloudinary.v2.uploader.upload('irrelevant', {
         regions: {
           'custom_1': [[1, 2], [3, 4], [5, 6], [7, 8]],
           'custom_2': [[10, 11], [12, 13], [14, 15]]
         }
-      });
+      }).catch(NOP);
 
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('regions', JSON.stringify({
         'custom_1': [[1, 2], [3, 4], [5, 6], [7, 8]],
@@ -51,13 +52,13 @@ describe('Uploader', () => {
   });
 
   describe('explicit', () => {
-    it('should send a request with encoded custom region gravity that represents a box', () => {
-      cloudinary.v2.uploader.explicit('irrelevant', {
+    it('should send a request with encoded custom region gravity that represents a box', async () => {
+      await cloudinary.v2.uploader.explicit('irrelevant', {
         regions: {
           'box_1': [[1, 2], [3, 4]],
           'box_2': [[5, 6], [7, 8]]
         }
-      });
+      }).catch(NOP);
 
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('regions', JSON.stringify({
         'box_1': [[1, 2], [3, 4]],
@@ -65,13 +66,13 @@ describe('Uploader', () => {
       }))));
     });
 
-    it('should send a request with encoded custom region gravity that represents a custom shape', () => {
-      cloudinary.v2.uploader.explicit('irrelevant', {
+    it('should send a request with encoded custom region gravity that represents a custom shape', async () => {
+      await cloudinary.v2.uploader.explicit('irrelevant', {
         regions: {
           'custom_1': [[1, 2], [3, 4], [5, 6], [7, 8]],
           'custom_2': [[10, 11], [12, 13], [14, 15]]
         }
-      });
+      }).catch(NOP);
 
       sinon.assert.calledWith(spy, sinon.match(helper.uploadParamMatcher('regions', JSON.stringify({
         'custom_1': [[1, 2], [3, 4], [5, 6], [7, 8]],

--- a/test/integration/api/uploader/slideshow_spec.js
+++ b/test/integration/api/uploader/slideshow_spec.js
@@ -1,4 +1,3 @@
-const Q = require('q');
 const cloudinary = require("../../../../cloudinary");
 const describe = require('../../../testUtils/suite');
 const TEST_ID = Date.now();
@@ -6,6 +5,7 @@ const TEST_ID = Date.now();
 const createTestConfig = require('../../../testUtils/createTestConfig');
 
 const testConstants = require('../../../testUtils/testConstants');
+const allSettled = require("../../../testUtils/helpers/allSettled");
 const UPLOADER_V2 = cloudinary.v2.uploader;
 
 const {
@@ -26,7 +26,7 @@ describe("create slideshow tests", function () {
     if (!(config.api_key && config.api_secret)) {
       expect().fail("Missing key and secret. Please set CLOUDINARY_URL.");
     }
-    return Q.allSettled([
+    return allSettled([
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG) : void 0,
       !cloudinary.config().keep_test_products ? cloudinary.v2.api.delete_resources_by_tag(TEST_TAG,
         {

--- a/test/integration/streaming_profiles_spec.js
+++ b/test/integration/streaming_profiles_spec.js
@@ -1,9 +1,9 @@
 let describe = require('../testUtils/suite');
 const keys = require('lodash/keys');
-const Q = require('q');
 const cloudinary = require("../../cloudinary");
 const helper = require("../spechelper");
 const TIMEOUT = require('../testUtils/testConstants').TIMEOUT;
+const allSettled = require('../testUtils/helpers/allSettled');
 const api = cloudinary.v2.api;
 
 describe('Cloudinary::Api', function () {
@@ -17,9 +17,9 @@ describe('Cloudinary::Api', function () {
   after(function () {
     cloudinary.config(true);
     if (cloudinary.config().keep_test_products) {
-      return Q.resolve();
+      return;
     }
-    return Q.allSettled([
+    return allSettled([
       cloudinary.v2.api.delete_streaming_profile(test_id_1),
       cloudinary.v2.api.delete_streaming_profile(test_id_1 + 'a'),
       cloudinary.v2.api.delete_streaming_profile(test_id_3)

--- a/test/spechelper.js
+++ b/test/spechelper.js
@@ -2,7 +2,6 @@ const isFunction = require('lodash/isFunction');
 const querystring = require('querystring');
 const sinon = require('sinon');
 const ClientRequest = require('_http_client').ClientRequest;
-const Q = require('q');
 const http = require('http');
 const https = require('https');
 // Load all our custom assertions
@@ -233,29 +232,23 @@ A test block
   @param {function} providedFunction  test function, accepting (mockXHR, writeSpy, requestSpy)
   @return {Promise}
 */
-exports.provideMockObjects = function (providedFunction) {
+exports.provideMockObjects = async function (providedFunction) {
   let requestSpy, writeSpy, mockXHR;
 
-  return Q.Promise(function (resolve, reject, notify) {
-    var result;
+  var result;
 
-    mockXHR = sinon.useFakeXMLHttpRequest();
-    writeSpy = sinon.spy(ClientRequest.prototype, 'write');
-    requestSpy = sinon.spy(api_http, 'request');
+  mockXHR = sinon.useFakeXMLHttpRequest();
+  writeSpy = sinon.spy(ClientRequest.prototype, 'write');
+  requestSpy = sinon.spy(api_http, 'request');
 
-    result = providedFunction(mockXHR, writeSpy, requestSpy);
-
-
-    if (result && isFunction(result.then)) {
-      return result.then(resolve);
-    } else {
-      return resolve(result);
-    }
-  }).finally(function () {
+  try {
+    result = await providedFunction(mockXHR, writeSpy, requestSpy);
+  } finally {
     requestSpy.restore();
     writeSpy.restore();
     mockXHR.restore();
-  }).done();
+  }
+  return result;
 };
 
 exports.setupCache = function () {

--- a/test/testUtils/helpers/allSettled.js
+++ b/test/testUtils/helpers/allSettled.js
@@ -1,0 +1,8 @@
+function allSettled(promises) {
+  return Promise.all(
+    promises.map((p = Promise.resolve()) => p.then((value) => ({ status: "fulfilled", value })).catch((reason) => ({ status: "rejected", reason }))
+    )
+  );
+}
+
+module.exports = allSettled;

--- a/test/testUtils/helpers/retry.js
+++ b/test/testUtils/helpers/retry.js
@@ -24,6 +24,6 @@ module.exports = async function retry(fn, limit = RETRY.LIMIT, delay= RETRY.DELA
     }
 
     // eslint-disable-next-line no-await-in-loop
-    await wait(delay)
+    await wait(delay)();
   }
 }

--- a/test/testUtils/helpers/wait.js
+++ b/test/testUtils/helpers/wait.js
@@ -4,10 +4,10 @@
  * @return {function(...item): Promise<...item>}
  */
 function wait(ms = 0) {
-  return (...rest) => {
+  return (value) => {
     return new Promise((resolve) => {
       setTimeout(() => {
-        resolve(...rest);
+        resolve(value);
       }, ms);
     });
   }

--- a/test/testUtils/reusableTests/api/toAcceptNextCursor.js
+++ b/test/testUtils/reusableTests/api/toAcceptNextCursor.js
@@ -1,13 +1,14 @@
 const registerReusableTest = require('../reusableTests').registerReusableTest;
 const sinon = require('sinon');
 const helper = require("../../../spechelper");
+const { NOP } = require('../../../../lib/utils');
 
 registerReusableTest("accepts next_cursor", function (testFunc, ...args) {
   it("Has a next cursor", function () {
-    return helper.provideMockObjects((mockXHR, writeSpy, requestSpy) => {
-      testFunc(...args, {
+    return helper.provideMockObjects(async (mockXHR, writeSpy, requestSpy) => {
+      await testFunc(...args, {
         next_cursor: 23452342
-      });
+      }).catch(NOP);
 
       // TODO Why aren't we sure what's called here?
       if (writeSpy.called) {

--- a/test/testUtils/reusableTests/api/toBeACursor.js
+++ b/test/testUtils/reusableTests/api/toBeACursor.js
@@ -1,13 +1,14 @@
 const registerReusableTest = require('../reusableTests').registerReusableTest;
 const sinon = require('sinon');
 const helper = require("../../../spechelper");
+const { NOP } = require('../../../../lib/utils');
 
 registerReusableTest("a list with a cursor", function (testFunc, ...args) {
   it("Cursor has max results", function () {
-    return helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
-      testFunc(...args, {
+    return helper.provideMockObjects(async function (mockXHR, writeSpy, requestSpy) {
+      await testFunc(...args, {
         max_results: 10
-      });
+      }).catch(NOP);
 
       // TODO why don't we know what is used?
       if (writeSpy.called) {
@@ -20,10 +21,10 @@ registerReusableTest("a list with a cursor", function (testFunc, ...args) {
     });
   });
   it("Cursor has next cursor", function () {
-    return helper.provideMockObjects(function (mockXHR, writeSpy, requestSpy) {
-      testFunc(...args, {
+    return helper.provideMockObjects(async function (mockXHR, writeSpy, requestSpy) {
+      await testFunc(...args, {
         next_cursor: 23452342
-      });
+      }).catch(NOP);
 
       // TODO why don't we know what is used?
       if (writeSpy.called) {

--- a/test/testUtils/suite.js
+++ b/test/testUtils/suite.js
@@ -12,4 +12,7 @@ function makeSuite(name, tests) {
   });
 }
 
+makeSuite.only = describe.only;
+makeSuite.skip = describe.skip;
+
 module.exports = makeSuite;

--- a/test/unit/api_restore_spec.js
+++ b/test/unit/api_restore_spec.js
@@ -5,6 +5,7 @@ const cloudinary = require('../../lib/cloudinary');
 const createTestConfig = require('../testUtils/createTestConfig');
 const helper = require('../spechelper');
 const api_http = require("https");
+const { NOP } = require('../../lib/utils');
 const ClientRequest = require('_http_client').ClientRequest;
 
 describe('api restore handlers', function () {
@@ -24,14 +25,14 @@ describe('api restore handlers', function () {
   });
 
   describe('.restore', function () {
-    it('sends public_ids and versions with JSON payload', function () {
+    it('sends public_ids and versions with JSON payload', async function () {
       const options = {
         resource_type: 'video',
         type: 'authenticated',
         versions: ['ver-1', 'ver-2']
       };
 
-      cloudinary.v2.api.restore(['pub-1', 'pub-2'], options);
+      await cloudinary.v2.api.restore(['pub-1', 'pub-2'], options).catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('resources/video/authenticated/restore'),
@@ -44,11 +45,11 @@ describe('api restore handlers', function () {
   });
 
   describe('.restore_by_asset_ids', function () {
-    it('sends asset_ids and versions with JSON payload', function () {
+    it('sends asset_ids and versions with JSON payload', async function () {
       const options = { versions: ['ver-3'] };
       const assetIds = ['asset-1', 'asset-2'];
 
-      cloudinary.v2.api.restore_by_asset_ids(assetIds, options);
+      await cloudinary.v2.api.restore_by_asset_ids(assetIds, options).catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('resources/restore'),
@@ -59,8 +60,8 @@ describe('api restore handlers', function () {
       sinon.assert.calledWith(mocked.write, sinon.match(helper.apiJsonParamMatcher('versions', ['ver-3'])));
     });
 
-    it('wraps a single asset id into an array before calling the API', function () {
-      cloudinary.v2.api.restore_by_asset_ids('single-asset-id');
+    it('wraps a single asset id into an array before calling the API', async function () {
+      await cloudinary.v2.api.restore_by_asset_ids('single-asset-id').catch(NOP);
 
       sinon.assert.calledWith(mocked.request, sinon.match({
         pathname: sinon.match('resources/restore'),


### PR DESCRIPTION
migrated away from q, and used native promises.

unhandled rejections in unit tests now cause the test runner to fail. ensured all rejections are ignored with no-op fn.

found and fixed several broken tests that did not report failures correctly.

fixed wait() not used correctly outside .then, as it's returning a higher order fn rather than the promise (to chain values in .then callbacks)

implemented a tiny test polyfill for Promise.allSettled to support older Node versions.

worked around a timezone issue and a test failing  when running it in ~1am locally, heh.

added ability to use .only/skip on the test proxy of mocha's describe fn

closes #711 
closes #686